### PR TITLE
fix: round up approval/disapproval quorum

### DIFF
--- a/src/VertexStrategy.sol
+++ b/src/VertexStrategy.sol
@@ -148,7 +148,7 @@ contract VertexStrategy is IVertexStrategy {
   /// @inheritdoc IVertexStrategy
   function getMinimumAmountNeeded(uint256 supply, uint256 minPct) public pure override returns (uint256) {
     // Rounding Up
-    return FixedPointMathLib.divWadUp((supply * minPct), ONE_HUNDRED_IN_BPS);
+    return FixedPointMathLib.mulDivUp(supply, minPct, ONE_HUNDRED_IN_BPS);
   }
 
   /// @inheritdoc IVertexStrategy


### PR DESCRIPTION
**Motivation:**

Solidity division tends to round down by default. For our quorum calculation we need to be able to round up incase there is a remainder during division.

**Modifications:**

Using the `mulDivUp` function in Solmate's FixedPointMathLib to round up the return value of `getMinimumAmountNeeded()` in VertexStrategy.

**Result:**

Approval/Disapproval quorums round up. Closes #45 
