### PR TITLE
feat: check slot0 in account delegatecalls

### DIFF
--- a/src/LlamaAccount.sol
+++ b/src/LlamaAccount.sol
@@ -39,6 +39,7 @@ contract LlamaAccount is ERC721Holder, ERC1155Holder, Initializable {
   error OnlyLlama();
   error Invalid0xRecipient();
   error FailedExecution(bytes result);
+  error Slot0Changed();
 
   modifier onlyLlama() {
     if (msg.sender != llamaCore) revert OnlyLlama();
@@ -49,11 +50,13 @@ contract LlamaAccount is ERC721Holder, ERC1155Holder, Initializable {
   // ======== Constants, Immutables and Storage Variables ========
   // =============================================================
 
+  /// @notice Llama instance.
+  /// @dev We intentionally put this before the `name` so it's packed with the `Initializable`
+  /// storage variables, that way we can only check one slot before and after a delegatecall.
+  address public llamaCore;
+
   /// @notice Name of this Llama Account.
   string public name;
-
-  /// @notice Llama instance.
-  address public llamaCore;
 
   // ======================================================
   // ======== Contract Creation and Initialization ========
@@ -239,8 +242,29 @@ contract LlamaAccount is ERC721Holder, ERC1155Holder, Initializable {
     bool success;
     bytes memory result;
 
-    if (withDelegatecall) (success, result) = target.delegatecall(callData);
-    else (success, result) = target.call{value: msg.value}(callData);
+    if (withDelegatecall) {
+      // Whenever we're executing arbitrary code in the context of this account, we want to ensure
+      // that none of the storage in this contract changes, as this could let someone who sneaks in
+      // a malicious (or buggy) target to take ownership of this contract. Slot 0 contains all
+      // relevant storage variables for security, so we check the value before and after execution
+      // to make sure it's unchanged. The contract name starts in slot 1, but it's not as important
+      // if that's changed (and it can be changed back), so to save gas we don't check the name.
+      // The storage layout of this contract is below:
+      //
+      // | Variable Name | Type    | Slot | Offset | Bytes |
+      // |---------------|---------|------|--------|-------|
+      // | _initialized  | uint8   | 0    | 0      | 1     |
+      // | _initializing | bool    | 0    | 1      | 1     |
+      // | llamaCore     | address | 0    | 2      | 20    |
+      // | name          | string  | 1    | 0      | 32    |
+
+      bytes32 originalStorage = _readSlot0();
+      (success, result) = target.delegatecall(callData);
+      bytes32 newStorage = _readSlot0();
+      if (originalStorage != newStorage) revert Slot0Changed();
+    } else {
+      (success, result) = target.call{value: msg.value}(callData);
+    }
 
     if (!success) revert FailedExecution(result);
     return result;
@@ -250,6 +274,14 @@ contract LlamaAccount is ERC721Holder, ERC1155Holder, Initializable {
   // ======== Internal Logic ========
   // ================================
 
+  /// @dev Reads slot 0 from storage, used to check that storage hasn't changed after delegatecall.
+  function _readSlot0() internal view returns (bytes32 slot0) {
+    assembly {
+      slot0 := sload(0)
+    }
+  }
+
+  /// @dev Increments a uint256 without checking for overflow.
   function _uncheckedIncrement(uint256 i) internal pure returns (uint256) {
     unchecked {
       return i + 1;

--- a/test/LlamaAccount.t.sol
+++ b/test/LlamaAccount.t.sol
@@ -10,6 +10,7 @@ import {IERC1155} from "@openzeppelin/token/ERC1155/IERC1155.sol";
 
 import {ICryptoPunk} from "test/external/ICryptoPunk.sol";
 import {MockExtension} from "test/mock/MockExtension.sol";
+import {MockMaliciousExtension} from "test/mock/MockMaliciousExtension.sol";
 import {LlamaTestSetup} from "test/utils/LlamaTestSetup.sol";
 
 import {
@@ -822,6 +823,20 @@ contract Execute is LlamaAccountTest {
     vm.expectRevert(abi.encodeWithSelector(LlamaAccount.FailedExecution.selector, ""));
     mpAccount1.execute(address(mockExtension), abi.encodePacked("", ""), true);
     vm.stopPrank();
+  }
+
+  function test_RevertIf_Slot0Changes() public {
+    MockMaliciousExtension mockExtension = new MockMaliciousExtension();
+
+    bytes memory data = abi.encodeCall(MockMaliciousExtension.attack1, ());
+    vm.prank(address(mpCore));
+    vm.expectRevert(LlamaAccount.Slot0Changed.selector);
+    mpAccount1.execute(address(mockExtension), data, true);
+
+    data = abi.encodeCall(MockMaliciousExtension.attack2, ());
+    vm.prank(address(mpCore));
+    vm.expectRevert(LlamaAccount.Slot0Changed.selector);
+    mpAccount1.execute(address(mockExtension), data, true);
   }
 }
 

--- a/test/mock/MockMaliciousExtension.sol
+++ b/test/mock/MockMaliciousExtension.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockMaliciousExtension {
+  // Zeros out the data at slot 0, where the initialization status and owner are stored.
+  function attack1() external {
+    assembly {
+      sstore(0, 0)
+    }
+  }
+
+  // Sets the same slot to some nonzero data.
+  function attack2() external {
+    uint256 x = type(uint256).max;
+    assembly {
+      sstore(0, x)
+    }
+  }
+}


### PR DESCRIPTION
**Motivation:**

Whenever we're executing arbitrary code in the context of an account (i.e. a delegatecall), we want to ensure that none of the storage in this contract changes, as this could let someone who sneaks in a malicious (or buggy) target to take ownership of this contract. Slot 0 contains all relevant storage variables for security, so we check the value before and after execution to make sure it's unchanged. The contract name starts in slot 1, but it's not as important if that's changed (and it can be changed back), so to save gas we don't check the name. The storage layout of this contract is below, obtained with `forge inspect LlamaAccount storage --pretty`:

```
| Variable Name | Type    | Slot | Offset | Bytes |
|---------------|---------|------|--------|-------|
| _initialized  | uint8   | 0    | 0      | 1     |
| _initializing | bool    | 0    | 1      | 1     |
| llamaCore     | address | 0    | 2      | 20    |
| name          | string  | 1    | 0      | 32    |
```
**Modifications:**

Add checks on the slot 0 value before and after the delegatecall

**Result:**

Malicious/buggy scripts cannot take ownership of the account
