### PR TITLE
fix: rename onlyLlama to OnlyLlamaOrRootLlama in LlamaPolicyMetadataParamRegistry

### DIFF
--- a/src/LlamaPolicyMetadataParamRegistry.sol
+++ b/src/LlamaPolicyMetadataParamRegistry.sol
@@ -11,10 +11,10 @@ contract LlamaPolicyMetadataParamRegistry {
   // ======== Errors and Modifiers ========
   // ======================================
 
-  error OnlyRootLlama();
+  error OnlyLlamaOrRootLlama();
 
-  modifier onlyRootLlama(LlamaCore rootLlamaCore) {
-    if ((msg.sender != address(ROOT_LLAMA)) && (msg.sender != address(rootLlamaCore))) revert OnlyRootLlama();
+  modifier onlyLlamaOrRootLlama(LlamaCore llamaCore) {
+    if ((msg.sender != address(ROOT_LLAMA)) && (msg.sender != address(llamaCore))) revert OnlyLlamaOrRootLlama();
     _;
   }
 
@@ -58,7 +58,7 @@ contract LlamaPolicyMetadataParamRegistry {
   /// @notice Sets the color code for SVG of a Llama Instance.
   /// @param llamaCore The Llama Instance.
   /// @param _color The color code as a hex value (eg. #00FF00)
-  function setColor(LlamaCore llamaCore, string memory _color) external onlyRootLlama(llamaCore) {
+  function setColor(LlamaCore llamaCore, string memory _color) external onlyLlamaOrRootLlama(llamaCore) {
     color[llamaCore] = _color;
     emit ColorSet(llamaCore, _color);
   }
@@ -66,7 +66,7 @@ contract LlamaPolicyMetadataParamRegistry {
   /// @notice Sets the logo for SVG of a Llama Instance.
   /// @param llamaCore The Llama Instance.
   /// @param _logo The logo.
-  function setLogo(LlamaCore llamaCore, string memory _logo) external onlyRootLlama(llamaCore) {
+  function setLogo(LlamaCore llamaCore, string memory _logo) external onlyLlamaOrRootLlama(llamaCore) {
     logo[llamaCore] = _logo;
     emit LogoSet(llamaCore, _logo);
   }

--- a/test/LlamaPolicyMetadataParamRegistry.t.sol
+++ b/test/LlamaPolicyMetadataParamRegistry.t.sol
@@ -55,7 +55,7 @@ contract SetColor is LlamaPolicyMetadataParamRegistryTest {
 
   function testFuzz_RevertIf_CallerIsNotLlama(address caller, LlamaCore llamaCore, string memory color) public {
     vm.assume(caller != address(rootCore) && caller != address(llamaCore));
-    vm.expectRevert(LlamaPolicyMetadataParamRegistry.OnlyRootLlama.selector);
+    vm.expectRevert(LlamaPolicyMetadataParamRegistry.OnlyLlamaOrRootLlama.selector);
     vm.prank(caller);
     policyMetadataParamRegistry.setColor(llamaCore, color);
   }
@@ -84,7 +84,7 @@ contract SetLogo is LlamaPolicyMetadataParamRegistryTest {
 
   function testFuzz_RevertIf_CallerIsNotLlama(address caller, LlamaCore llamaCore, string memory logo) public {
     vm.assume(caller != address(rootCore) && caller != address(llamaCore));
-    vm.expectRevert(LlamaPolicyMetadataParamRegistry.OnlyRootLlama.selector);
+    vm.expectRevert(LlamaPolicyMetadataParamRegistry.OnlyLlamaOrRootLlama.selector);
     vm.prank(caller);
     policyMetadataParamRegistry.setLogo(llamaCore, logo);
   }


### PR DESCRIPTION
**Motivation:**

In the other contracts the onlyLlama only refers to the llamaCore but in LlamaPolicyMetadataParamRegistry onlyLlama refers to llamaCore OR rootLlama.

Links to spearbit comment:
- https://github.com/spearbit-audits/review-llama/pull/8#discussion_r1181662799

**Modifications:**

- renamed onlyLlama to OnlyLlamaOrRootLlama in LlamaPolicyMetadataParamRegistry
- adjusted test suite accordingly

**Result:**

more accurate modifier and error naming in LlamaPolicyMetadataParamRegistry
