### PR TITLE
example: single use script with hidden calldata

### DIFF
--- a/src/lib/Structs.sol
+++ b/src/lib/Structs.sol
@@ -28,6 +28,7 @@ struct PermissionData {
 
 struct ActionInfo {
   uint256 id; // ID of the action.
+  uint8 role; // Role the action was created under.
   address creator; // Address that created the action.
   ILlamaStrategy strategy; // Strategy used to govern the action.
   address target; // Contract being called by an action.
@@ -40,6 +41,7 @@ struct Action {
   // make action creation cheaper. The hash is computed by taking the keccak256 hash of the
   // concatenation of the each field in the `ActionInfo` struct.
   bytes32 infoHash;
+  bool isScript; // Type of action.
   bool executed; // Has action executed.
   bool canceled; // Is action canceled.
   uint64 creationTime; // The timestamp when action was created (used for policy snapshots).

--- a/src/llama-scripts/SingleUseScript.sol
+++ b/src/llama-scripts/SingleUseScript.sol
@@ -10,22 +10,29 @@ import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
 /// @dev This script is meant to be delegate called by the core contract, which informs our use of `SELF` and
 /// `address(this)`.
 abstract contract SingleUseScript {
-  bytes32 public immutable SELF_PERMISSION_ID;
   address public immutable SELF;
-  uint8 public immutable ROLE;
 
-  constructor(ILlamaStrategy strategy, uint8 role, bytes4 selector) {
+  constructor() {
     SELF = address(this);
-    SELF_PERMISSION_ID = keccak256(abi.encode(SELF, selector, strategy));
-    ROLE = role;
   }
 
   /// @dev Add this to your script's methods to unauthorize the script after it has been run once.
   modifier unauthorizeAfterRun() {
     _;
+    // First we unauthorize the script itself.
     LlamaCore core = LlamaCore(address(this));
     LlamaPolicy policy = LlamaPolicy(core.policy());
     core.authorizeScript(SELF, false);
-    policy.setRolePermission(ROLE, SELF_PERMISSION_ID, false);
+
+    // Now we remove permission for the role to call this script.
+    // Usage of this approach requires "hidden" calldata to be appended to the delegatecall, i.e.
+    // extra data not necessarily required by the script's signature. The specific data we need
+    // is just the role, selector, and strategy address, which we expect to be ABI encoded as the
+    // last 3 words of calldata.
+    (uint8 role, bytes4 selector, address strategy) =
+      abi.decode(msg.data[msg.data.length - 96:], (uint8, bytes4, address));
+
+    bytes32 permissionId = keccak256(abi.encode(SELF, selector, strategy));
+    policy.setRolePermission(role, permissionId, false);
   }
 }

--- a/test/mock/MockSingleUseScript.sol
+++ b/test/mock/MockSingleUseScript.sol
@@ -12,7 +12,7 @@ import {MockProtocol} from "test/mock/MockProtocol.sol";
 /// @dev This script is meant to be delegate called by the core contract, which informs our use of `SELF` and
 /// `address(this)`.
 contract MockSingleUseScript is SingleUseScript {
-  constructor(ILlamaStrategy strategy, uint8 role, bytes4 selector) SingleUseScript(strategy, role, selector) {}
+  constructor(ILlamaStrategy strategy, uint8 role, bytes4 selector) SingleUseScript() {}
 
   function pauseMockProtocol(MockProtocol mp, bool isPaused) external unauthorizeAfterRun {
     mp.pause(isPaused);


### PR DESCRIPTION
**Motivation:**

Ref this conversation: https://github.com/llamaxyz/llama/pull/278/files#r1184500137

The proposed changes are an idea on how we can solve two problems:
1. A way to identify if an action is a call or delegatecall at action creation time, and preserve that during action execution. (See https://github.com/spearbit-audits/review-llama/issues/12)
2. A way guarantee that a script will unauthorize itself, when desired

**Modifications:**

This doesn't actually compile because it's just an example and not all required changes are implementey (notably the `uint8 role` addition to the `ActionInfo` struct).

The result is that delegatecalls (scripts) always have hidden data appended to them, but calls never do. This is because some calls may revert if the payload has hidden data (e.g. calls to USDT), but we have control over scripts, so can guarantee they always support hidden data. Note that supporting hidden data is the default behavior of solidity, and contracts like USDT explicitly override this (which was to mitigate old solidity bugs).

**Result:**

See above. Leaving this as a draft since it's a POC and doesn't compile