### PR TITLE
fix: executeAction checks msg.value with strict equality to actionInfo.value

### DIFF
--- a/src/LlamaCore.sol
+++ b/src/LlamaCore.sol
@@ -25,7 +25,7 @@ contract LlamaCore is Initializable {
   error DuplicateCast();
   error FailedActionExecution(bytes reason);
   error InfoHashMismatch();
-  error InsufficientMsgValue();
+  error IncorrectMsgValue();
   error InvalidActionState(ActionState expected);
   error InvalidPolicyholder();
   error InvalidSignature();
@@ -291,7 +291,7 @@ contract LlamaCore is Initializable {
     // Initial checks that action is ready to execute.
     if (getActionState(actionInfo) != ActionState.Queued) revert InvalidActionState(ActionState.Queued);
     if (block.timestamp < action.minExecutionTime) revert TimelockNotFinished();
-    if (msg.value != actionInfo.value) revert InsufficientMsgValue();
+    if (msg.value != actionInfo.value) revert IncorrectMsgValue();
 
     action.executed = true;
 

--- a/test/LlamaCore.t.sol
+++ b/test/LlamaCore.t.sol
@@ -966,7 +966,7 @@ contract ExecuteAction is LlamaCoreTest {
     }
   }
 
-  function testFuzz_RevertIf_InsufficientMsgValue(uint256 value) public {
+  function testFuzz_RevertIf_IncorrectMsgValue(uint256 value) public {
     vm.assume(value != 1 ether);
     bytes memory data = abi.encodeCall(MockProtocol.receiveEth, ());
     vm.prank(actionCreatorAaron);
@@ -993,7 +993,7 @@ contract ExecuteAction is LlamaCoreTest {
     (bool status, bytes memory _data) =
       address(mpCore).call{value: value}((abi.encodeCall(mpCore.executeAction, (_actionInfo))));
     assertFalse(status, "expectRevert: call did not revert");
-    assertEq(_data, bytes.concat(LlamaCore.InsufficientMsgValue.selector));
+    assertEq(_data, bytes.concat(LlamaCore.IncorrectMsgValue.selector));
   }
 
   function test_RevertIf_FailedActionExecution() public {


### PR DESCRIPTION
**Motivation:**

- (https://github.com/spearbit-audits/review-llama/issues/26)

**Modifications:**

- added a strict equality check in `LlamaCore::executeAction` to ensure the msg.value == the value specified at action creation
- updated the `testFuzz_RevertIf_InsufficientMsgValue` to be more robust to test the new behavior

**Result:**

- issue 26 in the spearbit audit repo is resolved
