### PR TITLE
fix: Quantity in `RoleAssigned` event in `LlamaPolicy`

### DIFF
--- a/src/LlamaPolicy.sol
+++ b/src/LlamaPolicy.sol
@@ -44,7 +44,7 @@ contract LlamaPolicy is ERC721NonTransferableMinimalProxy {
   // ======== Events ========
   // ========================
 
-  event RoleAssigned(address indexed policyholder, uint8 indexed role, uint256 expiration, RoleSupply roleSupply);
+  event RoleAssigned(address indexed policyholder, uint8 indexed role, uint64 expiration, uint128 quantity);
   event RoleInitialized(uint8 indexed role, RoleDescription description);
   event RolePermissionAssigned(uint8 indexed role, bytes32 indexed permissionId, bool hasPermission);
 
@@ -388,7 +388,7 @@ contract LlamaPolicy is ERC721NonTransferableMinimalProxy {
 
     currentRoleSupply.numberOfHolders = newNumberOfHolders;
     currentRoleSupply.totalQuantity = newTotalQuantity;
-    emit RoleAssigned(policyholder, role, expiration, currentRoleSupply);
+    emit RoleAssigned(policyholder, role, expiration, quantity);
   }
 
   function _setRolePermission(uint8 role, bytes32 permissionId, bool hasPermission) internal {


### PR DESCRIPTION
**Motivation:**

https://github.com/spearbit-audits/review-llama/issues/28

The `RoleAssigned` event in `LlamaPolicy` emits the `currentRoleSupply` instead of the `quantity`.

From an offchain perspective, there is currently no way to get the quantity assigned for a role to a policyholder at Role Assignment time. The event would be more useful if it emitted quantity instead of currentRoleSupply (since the latter can be just be calculated offchain from the former).

**Modifications:**

* Changes `emit RoleAssigned(policyholder, role, expiration, currentRoleSupply);` to `emit RoleAssigned(policyholder, role, expiration, quantity);`
* Uses `uint64` for expiration in the RoleAssigned event.
* Appropriate test case changes

**Result:**

Fixes the above issue
