### PR TITLE
fix: validate min execution time returned by strategy

### DIFF
--- a/src/LlamaCore.sol
+++ b/src/LlamaCore.sol
@@ -31,6 +31,7 @@ contract LlamaCore is Initializable {
   error InvalidPolicyholder();
   error InvalidSignature();
   error InvalidStrategy();
+  error MinExecutionTimeCannotBeInThePast();
   error OnlyLlama();
   error PolicyholderDoesNotHavePermission();
   error Slot0Changed();
@@ -278,6 +279,7 @@ contract LlamaCore is Initializable {
     if (getActionState(actionInfo) != ActionState.Approved) revert InvalidActionState(ActionState.Approved);
 
     uint64 minExecutionTime = actionInfo.strategy.minExecutionTime(actionInfo);
+    if (minExecutionTime < block.timestamp) revert MinExecutionTimeCannotBeInThePast();
     action.minExecutionTime = minExecutionTime;
     emit ActionQueued(actionInfo.id, msg.sender, actionInfo.strategy, actionInfo.creator, minExecutionTime);
   }

--- a/test/LlamaCore.t.sol
+++ b/test/LlamaCore.t.sol
@@ -853,6 +853,49 @@ contract QueueAction is LlamaCoreTest {
     vm.expectRevert(LlamaCore.InfoHashMismatch.selector);
     mpCore.queueAction(actionInfo);
   }
+
+  function testFuzz_RevertIf_MinExecutionTimeIsInThePast(uint64 blockTimestamp, uint64 minExecutionTime) public {
+    blockTimestamp = toUint64(bound(blockTimestamp, block.timestamp, type(uint64).max / 2)); // Arbitrary bound that
+      // won't revert.
+    minExecutionTime = toUint64(bound(minExecutionTime, 0, blockTimestamp));
+    vm.warp(blockTimestamp);
+
+    // Approve an action.
+    ActionInfo memory actionInfo = _createAction();
+    _approveAction(approverAdam, actionInfo);
+    _approveAction(approverAlicia, actionInfo);
+    vm.warp(block.timestamp + 6 days);
+    assertEq(mpStrategy1.isActionApproved(actionInfo), true);
+
+    // Queue reverts because minExecutionTime is in the past.
+    assertEq(uint8(mpCore.getActionState(actionInfo)), uint8(ActionState.Approved));
+    vm.mockCall(
+      address(actionInfo.strategy),
+      abi.encodeWithSelector(ILlamaStrategy.minExecutionTime.selector),
+      abi.encode(minExecutionTime)
+    );
+    vm.expectRevert(LlamaCore.MinExecutionTimeCannotBeInThePast.selector);
+    mpCore.queueAction(actionInfo);
+  }
+
+  function testFuzz_SuccessfullyQueuesAction(uint64 blockTimestamp, uint64 minExecutionTime) public {
+    blockTimestamp = toUint64(bound(blockTimestamp, block.timestamp, type(uint64).max / 2)); // Arbitrary bound that
+      // won't revert.
+    minExecutionTime = toUint64(bound(minExecutionTime, 0, blockTimestamp));
+    vm.warp(blockTimestamp);
+
+    // Approve an action.
+    ActionInfo memory actionInfo = _createAction();
+    _approveAction(approverAdam, actionInfo);
+    _approveAction(approverAlicia, actionInfo);
+    vm.warp(block.timestamp + 6 days);
+    assertEq(mpStrategy1.isActionApproved(actionInfo), true);
+
+    // Queue it.
+    assertEq(uint8(mpCore.getActionState(actionInfo)), uint8(ActionState.Approved));
+    mpCore.queueAction(actionInfo);
+    assertEq(uint8(mpCore.getActionState(actionInfo)), uint8(ActionState.Queued));
+  }
 }
 
 contract ExecuteAction is LlamaCoreTest {


### PR DESCRIPTION
**Motivation:**

https://github.com/spearbit-audits/review-llama/issues/42

**Modifications:**

Adds a new error `MinExecutionTimeCannotBeInThePast` which is thrown if the strategy returns a timestamp that is below the current block timestamp.

I'm open to alternative names for `MinExecutionTimeCannotBeInThePast`.

Also adds corresponding tests

**Result:**

Stricter validation on min execution time returned by strategy
