### PR TITLE
fix: removed revokePolicies overload

### DIFF
--- a/src/LlamaPolicy.sol
+++ b/src/LlamaPolicy.sol
@@ -194,18 +194,6 @@ contract LlamaPolicy is ERC721NonTransferableMinimalProxy {
     _burn(_tokenId(policyholder));
   }
 
-  /// @notice Revokes all `roles` from the `policyholder` and burns their policy.
-  /// @dev This method only exists to ensure policies can still be revoked in the case where the
-  /// other `revokePolicy` method cannot be executed due to needed more gas than the block gas limit.
-  function revokePolicy(address policyholder, uint8[] calldata roles) external onlyLlama {
-    if (balanceOf(policyholder) == 0) revert AddressDoesNotHoldPolicy(policyholder);
-    for (uint256 i = 0; i < roles.length; i = LlamaUtils.uncheckedIncrement(i)) {
-      if (roles[i] == 0) revert AllHoldersRole();
-      _setRoleHolder(roles[i], policyholder, 0, 0);
-    }
-    _burn(_tokenId(policyholder));
-  }
-
   /// @notice Updates the description of a role.
   /// @param role ID of the role to update.
   /// @param description New description of the role.

--- a/src/llama-scripts/GovernanceScript.sol
+++ b/src/llama-scripts/GovernanceScript.sol
@@ -25,11 +25,6 @@ contract GovernanceScript {
     RoleDescription description;
   }
 
-  struct RevokePolicy {
-    address policyholder;
-    uint8[] roles;
-  }
-
   struct RevokeExpiredRole {
     uint8 role;
     address policyholder;
@@ -156,7 +151,7 @@ contract GovernanceScript {
   }
 
   function revokePoliciesAndUpdateRoleDescriptions(
-    RevokePolicy[] calldata _revokePolicies,
+    address[] calldata _revokePolicies,
     UpdateRoleDescription[] calldata _updateRoleDescriptions
   ) external {
     revokePolicies(_revokePolicies);
@@ -164,7 +159,7 @@ contract GovernanceScript {
   }
 
   function revokePoliciesAndUpdateRoleDescriptionsAndSetRoleHolders(
-    RevokePolicy[] calldata _revokePolicies,
+    address[] calldata _revokePolicies,
     UpdateRoleDescription[] calldata _updateRoleDescriptions,
     SetRoleHolder[] calldata _setRoleHolders
   ) external {
@@ -218,12 +213,10 @@ contract GovernanceScript {
 
   /// @notice if the roles array is empty, it will revoke all roles iteratively. Pass all roles in as an array otherwise
   /// if the policyholder has too many roles.
-  function revokePolicies(RevokePolicy[] calldata _revokePolicies) public {
+  function revokePolicies(address[] calldata _revokePolicies) public {
     (, LlamaPolicy policy) = _context();
     for (uint256 i = 0; i < _revokePolicies.length; i++) {
-      uint256 rolesLength = _revokePolicies[i].roles.length;
-      if (rolesLength == 0) policy.revokePolicy(_revokePolicies[i].policyholder);
-      else policy.revokePolicy(_revokePolicies[i].policyholder, _revokePolicies[i].roles);
+      policy.revokePolicy(_revokePolicies[i]);
     }
   }
 

--- a/test/llama-scripts/GovernanceScript.t.sol
+++ b/test/llama-scripts/GovernanceScript.t.sol
@@ -363,26 +363,10 @@ contract RevokeExpiredRoles is GovernanceScriptTest {
 
 contract RevokePolicies is GovernanceScriptTest {
   uint8[] public roles;
-  GovernanceScript.RevokePolicy[] public revokePolicies;
+  address[] public revokePolicies;
 
   function test_revokePolicies() public {
-    revokePolicies.push(GovernanceScript.RevokePolicy(address(disapproverDave), roles));
-    bytes memory data = abi.encodeWithSelector(REVOKE_POLICIES_SELECTOR, revokePolicies);
-    vm.prank(actionCreatorAaron);
-    uint256 actionId = mpCore.createAction(uint8(Roles.ActionCreator), mpStrategy2, address(governanceScript), 0, data);
-    ActionInfo memory actionInfo = ActionInfo(
-      actionId, actionCreatorAaron, uint8(Roles.ActionCreator), mpStrategy2, address(governanceScript), 0, data
-    );
-    vm.warp(block.timestamp + 1);
-    _approveAction(actionInfo);
-    vm.expectEmit();
-    emit RoleAssigned(address(disapproverDave), uint8(Roles.Disapprover), 0, 0);
-    mpCore.executeAction(actionInfo);
-  }
-
-  function test_revokePoliciesOverload() public {
-    roles.push(uint8(Roles.Disapprover));
-    revokePolicies.push(GovernanceScript.RevokePolicy(address(disapproverDave), roles));
+    revokePolicies.push(disapproverDave);
     bytes memory data = abi.encodeWithSelector(REVOKE_POLICIES_SELECTOR, revokePolicies);
     vm.prank(actionCreatorAaron);
     uint256 actionId = mpCore.createAction(uint8(Roles.ActionCreator), mpStrategy2, address(governanceScript), 0, data);


### PR DESCRIPTION
**Motivation:**

https://github.com/spearbit-audits/review-llama/issues/31, https://github.com/spearbit-audits/review-llama/issues/35

**Modifications:**

- Removed the `revokePoliciesOverload` function and tests, as well as adjusted any existing tests to use the canonical revokePolicies method from now on

**Result:**

- spearbit issue 31 & 35 are resolved, and `revokePolicy` is now only one method, with gaurantees about removing every role
