### PR TITLE
chore: use dedicated runner for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: llama-ci
     steps:
       - uses: actions/checkout@v3
 
@@ -25,7 +25,7 @@ jobs:
           FOUNDRY_PROFILE=ci forge build --sizes --skip test
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: llama-ci
     steps:
       - uses: actions/checkout@v3
 
@@ -36,7 +36,7 @@ jobs:
         run: forge test -vvv
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: llama-ci
     steps:
       - uses: actions/checkout@v3
 
@@ -78,7 +78,7 @@ jobs:
           minimum-coverage: 80 # Set coverage threshold.
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: llama-ci
     steps:
       - uses: actions/checkout@v3
 
@@ -89,7 +89,7 @@ jobs:
         run: forge fmt --check
 
   scopelint:
-    runs-on: ubuntu-latest
+    runs-on: llama-ci
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
**Motivation:**

Run our CI on an improved machine to fix memory error.

**Modifications:**

Deployed `llama-ci` in the Github admin UI and updated our workflows accordingly.

**Result:**

We will be able to run tests in CI again.
