### PR TITLE
fix: use dedicated runner and pin foundry version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-e15e33a07c0920189fc336391f538c3dad53da73
 
       - name: Build contracts
         run: |
@@ -33,6 +35,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-e15e33a07c0920189fc336391f538c3dad53da73
 
       - name: Run tests
         run: forge test -vvv
@@ -45,6 +49,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-e15e33a07c0920189fc336391f538c3dad53da73
 
       - name: Run coverage
         run: forge coverage --report summary --report lcov
@@ -88,6 +94,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-e15e33a07c0920189fc336391f538c3dad53da73
 
       - name: Check formatting
         run: forge fmt --check
@@ -100,6 +108,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-e15e33a07c0920189fc336391f538c3dad53da73
 
       - name: Install scopelint
         uses: engineerd/configurator@v0.0.8


### PR DESCRIPTION
**Motivation:**

This change ensures we have a large enough machine to run our foundry test suite and we're pinned to a stable version of foundry.

**Modifications:**

Pinning foundry to a stable version to avoid an inconsistent CI experience as we finish our Spearbit followups. We should remove this change and fix the resulting test failures after we finish all of the follow ups. I also update the `ci.yml` file to use our dedicated enterprise runner group.

**Result:**

We will have an improved developer experience for finishing the audit follow ups.
