### PR TITLE
fix : nonconforming EIP-712 hash

### DIFF
--- a/test/LlamaCore.t.sol
+++ b/test/LlamaCore.t.sol
@@ -92,14 +92,14 @@ contract LlamaCoreTest is LlamaTestSetup, LlamaCoreSigUtils {
     vm.expectEmit();
     emit ApprovalCast(actionInfo.id, _policyholder, uint8(Roles.Approver), 1, "");
     vm.prank(_policyholder);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
   }
 
   function _disapproveAction(address _policyholder, ActionInfo memory actionInfo) public {
     vm.expectEmit();
     emit DisapprovalCast(actionInfo.id, _policyholder, uint8(Roles.Disapprover), 1, "");
     vm.prank(_policyholder);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
   }
 
   function _queueAction(ActionInfo memory actionInfo) public {
@@ -1314,7 +1314,7 @@ contract CastApproval is LlamaCoreTest {
     vm.expectEmit();
     emit ApprovalCast(actionInfo.id, approverAdam, uint8(Roles.Approver), 1, reason);
     vm.prank(approverAdam);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver), reason);
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo, reason);
   }
 
   function test_RevertIf_ActionNotActive() public {
@@ -1326,7 +1326,7 @@ contract CastApproval is LlamaCoreTest {
     mpCore.queueAction(actionInfo);
 
     vm.expectRevert(abi.encodePacked(LlamaCore.InvalidActionState.selector, uint256(ActionState.Queued)));
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
   }
 
   function test_RevertIf_DuplicateApproval() public {
@@ -1334,7 +1334,7 @@ contract CastApproval is LlamaCoreTest {
 
     vm.expectRevert(LlamaCore.DuplicateCast.selector);
     vm.prank(approverAdam);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
   }
 
   function test_RevertIf_InvalidPolicyholder() public {
@@ -1342,10 +1342,10 @@ contract CastApproval is LlamaCoreTest {
     vm.prank(notPolicyholder);
 
     vm.expectRevert(LlamaCore.InvalidPolicyholder.selector);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
 
     vm.prank(approverAdam);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
   }
 
   function test_RevertIf_NoQuantity() public {
@@ -1364,7 +1364,7 @@ contract CastApproval is LlamaCoreTest {
         LlamaCore.CannotCastWithZeroQuantity.selector, actionCreatorAaron, uint8(Roles.ActionCreator)
       )
     );
-    mpCore.castApproval(actionInfo, uint8(Roles.ActionCreator));
+    mpCore.castApproval(uint8(Roles.ActionCreator), actionInfo);
   }
 }
 
@@ -1386,7 +1386,7 @@ contract CastApprovalBySig is LlamaCoreTest {
   }
 
   function castApprovalBySig(ActionInfo memory actionInfo, uint8 v, bytes32 r, bytes32 s) internal {
-    mpCore.castApprovalBySig(actionInfo, uint8(Roles.Approver), "", approverAdam, v, r, s);
+    mpCore.castApprovalBySig(approverAdam, uint8(Roles.Approver), actionInfo, "", v, r, s);
   }
 
   function test_CastsApprovalBySig() public {
@@ -1500,7 +1500,7 @@ contract CastDisapproval is LlamaCoreTest {
     vm.expectEmit();
     emit DisapprovalCast(actionInfo.id, disapproverDrake, uint8(Roles.Disapprover), 1, "");
 
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
 
     assertEq(mpCore.getAction(0).totalDisapprovals, 1);
     assertEq(mpCore.disapprovals(0, disapproverDrake), true);
@@ -1511,14 +1511,14 @@ contract CastDisapproval is LlamaCoreTest {
     vm.expectEmit();
     emit DisapprovalCast(actionInfo.id, disapproverDrake, uint8(Roles.Disapprover), 1, reason);
     vm.prank(disapproverDrake);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover), reason);
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo, reason);
   }
 
   function test_RevertIf_ActionNotQueued() public {
     ActionInfo memory actionInfo = _createAction();
 
     vm.expectRevert(abi.encodePacked(LlamaCore.InvalidActionState.selector, uint256(ActionState.Active)));
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
   }
 
   function test_RevertIf_DuplicateDisapproval() public {
@@ -1528,7 +1528,7 @@ contract CastDisapproval is LlamaCoreTest {
 
     vm.expectRevert(LlamaCore.DuplicateCast.selector);
     vm.prank(disapproverDrake);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
   }
 
   function test_RevertIf_InvalidPolicyholder() public {
@@ -1537,19 +1537,19 @@ contract CastDisapproval is LlamaCoreTest {
     vm.prank(notPolicyholder);
 
     vm.expectRevert(LlamaCore.InvalidPolicyholder.selector);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
 
     vm.prank(disapproverDrake);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
   }
 
   function test_FailsIfDisapproved() public {
     ActionInfo memory actionInfo = _createApproveAndQueueAction();
 
     vm.prank(disapproverDave);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
     vm.prank(disapproverDrake);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
 
     ActionState state = mpCore.getActionState(actionInfo);
     assertEq(uint8(state), uint8(ActionState.Failed));
@@ -1582,7 +1582,7 @@ contract CastDisapproval is LlamaCoreTest {
       )
     );
     vm.prank(actionCreatorAaron);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.ActionCreator));
+    mpCore.castDisapproval(uint8(Roles.ActionCreator), actionInfo);
   }
 }
 
@@ -1604,7 +1604,7 @@ contract CastDisapprovalBySig is LlamaCoreTest {
   }
 
   function castDisapprovalBySig(ActionInfo memory actionInfo, uint8 v, bytes32 r, bytes32 s) internal {
-    mpCore.castDisapprovalBySig(actionInfo, uint8(Roles.Disapprover), "", disapproverDrake, v, r, s);
+    mpCore.castDisapprovalBySig(disapproverDrake, uint8(Roles.Disapprover), actionInfo, "", v, r, s);
   }
 
   function _createApproveAndQueueAction() internal returns (ActionInfo memory actionInfo) {
@@ -1701,7 +1701,7 @@ contract CastDisapprovalBySig is LlamaCoreTest {
 
     // Second disapproval.
     vm.prank(disapproverDave);
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
 
     // Assertions.
     ActionState state = mpCore.getActionState(actionInfo);

--- a/test/LlamaStrategy.t.sol
+++ b/test/LlamaStrategy.t.sol
@@ -223,7 +223,7 @@ contract LlamaStrategyTest is LlamaTestSetup {
     for (uint256 i = 0; i < numberOfApprovals; i++) {
       address _policyholder = address(uint160(i + 100));
       vm.prank(_policyholder);
-      mpCore.castApproval(actionInfo, uint8(Roles.TestRole1));
+      mpCore.castApproval(uint8(Roles.TestRole1), actionInfo);
     }
   }
 
@@ -231,7 +231,7 @@ contract LlamaStrategyTest is LlamaTestSetup {
     for (uint256 i = 0; i < numberOfDisapprovals; i++) {
       address _policyholder = address(uint160(i + 100));
       vm.prank(_policyholder);
-      mpCore.castDisapproval(actionInfo, uint8(Roles.TestRole1));
+      mpCore.castDisapproval(uint8(Roles.TestRole1), actionInfo);
     }
   }
 
@@ -785,7 +785,7 @@ contract IsActionApproved is LlamaStrategyTest {
   function testFuzz_RevertForNonExistentActionId(ActionInfo calldata actionInfo) public {
     vm.expectRevert(LlamaCore.InfoHashMismatch.selector);
     vm.prank(address(approverAdam));
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
   }
 }
 
@@ -804,7 +804,7 @@ contract ValidateActionCancelation is LlamaStrategyTest {
     ActionInfo memory actionInfo = createAction(testStrategy);
 
     vm.prank(address(approverAdam));
-    mpCore.castApproval(actionInfo, uint8(Roles.ForceApprover));
+    mpCore.castApproval(uint8(Roles.ForceApprover), actionInfo);
 
     mpCore.queueAction(actionInfo);
 
@@ -829,7 +829,7 @@ contract ValidateActionCancelation is LlamaStrategyTest {
     ActionInfo memory actionInfo = createAction(testStrategy);
 
     vm.prank(address(approverAdam));
-    mpCore.castApproval(actionInfo, uint8(Roles.ForceApprover));
+    mpCore.castApproval(uint8(Roles.ForceApprover), actionInfo);
 
     mpCore.queueAction(actionInfo);
 
@@ -911,7 +911,7 @@ contract ValidateActionCancelation is LlamaStrategyTest {
   function testFuzz_RevertForNonExistentActionId(ActionInfo calldata actionInfo) public {
     vm.expectRevert(LlamaCore.InfoHashMismatch.selector);
     vm.prank(address(disapproverDave));
-    mpCore.castDisapproval(actionInfo, uint8(Roles.Disapprover));
+    mpCore.castDisapproval(uint8(Roles.Disapprover), actionInfo);
   }
 }
 
@@ -1280,7 +1280,7 @@ contract ValidateActionCreation is LlamaStrategyTest {
 
     vm.expectRevert(AbsoluteStrategy.DisapprovalDisabled.selector);
 
-    mpCore.castDisapproval(actionInfo, uint8(Roles.TestRole1));
+    mpCore.castDisapproval(uint8(Roles.TestRole1), actionInfo);
   }
 
   function test_CalculateSupplyWhenActionCreatorDoesNotHaveRole(uint256 _numberOfPolicies) external {

--- a/test/invariants/LlamaCore.invariants.t.sol
+++ b/test/invariants/LlamaCore.invariants.t.sol
@@ -232,7 +232,7 @@ contract LlamaCoreHandler is BaseHandler {
     }
 
     vm.prank(approver);
-    LLAMA_CORE.castApproval(actionInfos[actionId], uint8(Roles.Approver));
+    LLAMA_CORE.castApproval(uint8(Roles.Approver), actionInfos[actionId]);
     recordMetric("llamaCore_castApproval_approved");
   }
 
@@ -254,7 +254,7 @@ contract LlamaCoreHandler is BaseHandler {
     }
 
     vm.prank(disapprover);
-    LLAMA_CORE.castDisapproval(actionInfos[actionId], uint8(Roles.Disapprover));
+    LLAMA_CORE.castDisapproval(uint8(Roles.Disapprover), actionInfos[actionId]);
     recordMetric("llamaCore_castDisapproval_disapproved");
   }
 
@@ -350,7 +350,7 @@ contract LlamaFactoryInvariants is LlamaTestSetup {
 
   function approveAction(address policyholder, ActionInfo memory actionInfo) public {
     vm.prank(policyholder);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
   }
 
   // ======================================

--- a/test/llama-scripts/GovernanceScript.t.sol
+++ b/test/llama-scripts/GovernanceScript.t.sol
@@ -170,11 +170,11 @@ contract GovernanceScriptTest is LlamaTestSetup {
     vm.warp(block.timestamp + 1);
 
     vm.prank(approverAdam);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
     vm.prank(approverAlicia);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
     vm.prank(approverAndy);
-    mpCore.castApproval(actionInfo, uint8(Roles.Approver));
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo);
     mpCore.queueAction(actionInfo);
   }
 }

--- a/test/script/CreateAction.t.sol
+++ b/test/script/CreateAction.t.sol
@@ -101,7 +101,7 @@ contract Run is CreateActionTest {
     assertEq(uint8(rootLlama.getActionState(actionInfo)), uint8(ActionState.Active));
 
     vm.prank(LLAMA_INSTANCE_DEPLOYER); // This EOA has force-approval permissions.
-    rootLlama.castApproval(actionInfo, ACTION_CREATOR_ROLE_ID);
+    rootLlama.castApproval(ACTION_CREATOR_ROLE_ID, actionInfo);
 
     assertEq(uint8(rootLlama.getActionState(actionInfo)), uint8(ActionState.Approved));
 

--- a/test/utils/LlamaCoreSigUtils.sol
+++ b/test/utils/LlamaCoreSigUtils.sol
@@ -23,18 +23,18 @@ contract LlamaCoreSigUtils {
   }
 
   struct CastApproval {
-    ActionInfo actionInfo;
-    uint8 role;
-    string reason;
     address policyholder;
+    uint8 role;
+    ActionInfo actionInfo;
+    string reason;
     uint256 nonce;
   }
 
   struct CastDisapproval {
-    ActionInfo actionInfo;
-    uint8 role;
-    string reason;
     address policyholder;
+    uint8 role;
+    ActionInfo actionInfo;
+    string reason;
     uint256 nonce;
   }
 
@@ -49,12 +49,12 @@ contract LlamaCoreSigUtils {
 
   /// @notice EIP-712 castApproval typehash.
   bytes32 internal constant CAST_APPROVAL_TYPEHASH = keccak256(
-    "CastApproval(ActionInfo actionInfo,uint8 role,string reason,address policyholder,uint256 nonce)ActionInfo(uint256 id,address creator,uint8 creatorRole,address strategy,address target,uint256 value,bytes data)"
+    "CastApproval(address policyholder,uint8 role,ActionInfo actionInfo,string reason,uint256 nonce)ActionInfo(uint256 id,address creator,uint8 creatorRole,address strategy,address target,uint256 value,bytes data)"
   );
 
   /// @notice EIP-712 castDisapproval typehash.
   bytes32 internal constant CAST_DISAPPROVAL_TYPEHASH = keccak256(
-    "CastDisapproval(ActionInfo actionInfo,uint8 role,string reason,address policyholder,uint256 nonce)ActionInfo(uint256 id,address creator,uint8 creatorRole,address strategy,address target,uint256 value,bytes data)"
+    "CastDisapproval(address policyholder,uint8 role,ActionInfo actionInfo,string reason,uint256 nonce)ActionInfo(uint256 id,address creator,uint8 creatorRole,address strategy,address target,uint256 value,bytes data)"
   );
 
   /// @notice EIP-712 actionInfo typehash.
@@ -105,10 +105,10 @@ contract LlamaCoreSigUtils {
     return keccak256(
       abi.encode(
         CAST_APPROVAL_TYPEHASH,
-        getActionInfoHash(castApproval.actionInfo),
-        castApproval.role,
-        keccak256(bytes(castApproval.reason)),
         castApproval.policyholder,
+        castApproval.role,
+        getActionInfoHash(castApproval.actionInfo),
+        keccak256(bytes(castApproval.reason)),
         castApproval.nonce
       )
     );
@@ -125,10 +125,10 @@ contract LlamaCoreSigUtils {
     return keccak256(
       abi.encode(
         CAST_DISAPPROVAL_TYPEHASH,
-        getActionInfoHash(castDisapproval.actionInfo),
-        castDisapproval.role,
-        keccak256(bytes(castDisapproval.reason)),
         castDisapproval.policyholder,
+        castDisapproval.role,
+        getActionInfoHash(castDisapproval.actionInfo),
+        keccak256(bytes(castDisapproval.reason)),
         castDisapproval.nonce
       )
     );

--- a/test/utils/LlamaTestSetup.sol
+++ b/test/utils/LlamaTestSetup.sol
@@ -187,7 +187,7 @@ contract LlamaTestSetup is DeployLlama, CreateAction, Test {
       0, // value
       createActionCallData
     );
-    rootCore.castApproval(deployActionInfo, uint8(Roles.ActionCreator));
+    rootCore.castApproval(uint8(Roles.ActionCreator), deployActionInfo);
     rootCore.queueAction(deployActionInfo);
 
     // Advance the clock to execute the action.


### PR DESCRIPTION
**Motivation:**

https://github.com/spearbit-audits/review-llama/issues/48

**Modifications:**

* Removed the spaces(` ` ) after comma(`,`) in the  in the `CastApproval` and `CastDisapproval` typehashes.
* Refactored all the typed data hashes to their own internal functions for better readability
* Added `description` to `CreateAction` typehash
* Added `ActionInfo` typehash and used them in the `CastApproval` and `CastDisapproval` typehashes.
* Updated ordering of `createActionBySig` , `castApproval*` and `castDisapproval*` function parameters and respective typehashes to be consistent and more intuitive. 
* Respective updated tests.

**Result:**

Fixed above issue according to the following references:
1. https://github.com/ethereum/solidity/pull/14167/files
2. https://github.com/ethereum/solidity/pull/14167/files#diff-ee736161bf8212d777a9a154cbb9b19adb333a4417bab957256ed7cdb2dd3dffR35
