### PR TITLE
perf: dedupe policy SLOADs

### DIFF
--- a/src/strategies/AbsoluteStrategy.sol
+++ b/src/strategies/AbsoluteStrategy.sol
@@ -153,10 +153,11 @@ contract AbsoluteStrategy is ILlamaStrategy, Initializable {
 
   /// @inheritdoc ILlamaStrategy
   function validateActionCreation(ActionInfo calldata actionInfo) external view {
-    uint256 approvalPolicySupply = policy.getRoleSupplyAsQuantitySum(approvalRole);
+    LlamaPolicy llamaPolicy = policy; // Reduce SLOADs.
+    uint256 approvalPolicySupply = llamaPolicy.getRoleSupplyAsQuantitySum(approvalRole);
     if (approvalPolicySupply == 0) revert RoleHasZeroSupply(approvalRole);
 
-    uint256 disapprovalPolicySupply = policy.getRoleSupplyAsQuantitySum(disapprovalRole);
+    uint256 disapprovalPolicySupply = llamaPolicy.getRoleSupplyAsQuantitySum(disapprovalRole);
     if (disapprovalPolicySupply == 0) revert RoleHasZeroSupply(disapprovalRole);
 
     // If the action creator has the approval or disapproval role, reduce the total supply by 1.
@@ -165,10 +166,10 @@ contract AbsoluteStrategy is ILlamaStrategy, Initializable {
       // held by the action creator. Therefore we can reduce the total supply by the quantity held by
       // the action creator without overflow, since a policyholder can never have a quantity greater than
       // the total supply.
-      uint256 actionCreatorApprovalRoleQty = policy.getQuantity(actionInfo.creator, approvalRole);
+      uint256 actionCreatorApprovalRoleQty = llamaPolicy.getQuantity(actionInfo.creator, approvalRole);
       if (minApprovals > approvalPolicySupply - actionCreatorApprovalRoleQty) revert InsufficientApprovalQuantity();
 
-      uint256 actionCreatorDisapprovalRoleQty = policy.getQuantity(actionInfo.creator, disapprovalRole);
+      uint256 actionCreatorDisapprovalRoleQty = llamaPolicy.getQuantity(actionInfo.creator, disapprovalRole);
       if (
         minDisapprovals != type(uint128).max
           && minDisapprovals > disapprovalPolicySupply - actionCreatorDisapprovalRoleQty

--- a/src/strategies/RelativeStrategy.sol
+++ b/src/strategies/RelativeStrategy.sol
@@ -154,10 +154,11 @@ contract RelativeStrategy is ILlamaStrategy, Initializable {
 
   /// @inheritdoc ILlamaStrategy
   function validateActionCreation(ActionInfo calldata actionInfo) external {
-    uint256 approvalPolicySupply = policy.getRoleSupplyAsNumberOfHolders(approvalRole);
+    LlamaPolicy llamaPolicy = policy; // Reduce SLOADs.
+    uint256 approvalPolicySupply = llamaPolicy.getRoleSupplyAsNumberOfHolders(approvalRole);
     if (approvalPolicySupply == 0) revert RoleHasZeroSupply(approvalRole);
 
-    uint256 disapprovalPolicySupply = policy.getRoleSupplyAsNumberOfHolders(disapprovalRole);
+    uint256 disapprovalPolicySupply = llamaPolicy.getRoleSupplyAsNumberOfHolders(disapprovalRole);
     if (disapprovalPolicySupply == 0) revert RoleHasZeroSupply(disapprovalRole);
 
     // Save off the supplies to use for checking quorum.


### PR DESCRIPTION
**Motivation:**

https://github.com/spearbit-audits/review-llama/issues/22

**Modifications:**

- The duplicate `_validateActionInfoHash` checks in `_preCastAssertions` will be fixed in https://github.com/llamaxyz/llama/pull/320
- This PR just deduplicates the policy SLOADs in strategies when validating action creation, since there's up to 4 of them. Since these only cost 100 gas, I wanted to keep things readable and avoid e.g. passing more function params around, which is why no other changes were implemented

**Result:**

Reduced gas cost when creating an action
