### PR TITLE
fix: only allow `validateActionCreation` to be called by `LlamaCore`

### DIFF
--- a/src/LlamaCore.sol
+++ b/src/LlamaCore.sol
@@ -494,7 +494,7 @@ contract LlamaCore is Initializable {
 
     if (action.executed) return ActionState.Executed;
 
-    if (actionInfo.strategy.isActive(actionInfo)) return ActionState.Active;
+    if (actionInfo.strategy.isActionActive(actionInfo)) return ActionState.Active;
 
     if (!actionInfo.strategy.isActionApproved(actionInfo)) return ActionState.Failed;
 

--- a/src/interfaces/ILlamaStrategy.sol
+++ b/src/interfaces/ILlamaStrategy.sol
@@ -89,7 +89,7 @@ interface ILlamaStrategy {
   /// @notice Get whether an action is currently active.
   /// @param actionInfo Data required to create an action.
   /// @return Boolean value that is `true` if the action is currently active, `false` otherwise.
-  function isActive(ActionInfo calldata actionInfo) external view returns (bool);
+  function isActionActive(ActionInfo calldata actionInfo) external view returns (bool);
 
   /// @notice Get whether an action has passed the approval process.
   /// @param actionInfo Data required to create an action.

--- a/src/strategies/LlamaAbsoluteStrategyBase.sol
+++ b/src/strategies/LlamaAbsoluteStrategyBase.sol
@@ -263,7 +263,7 @@ abstract contract LlamaAbsoluteStrategyBase is ILlamaStrategy, Initializable {
   // -------- When Determining Action State --------
 
   /// @inheritdoc ILlamaStrategy
-  function isActive(ActionInfo calldata actionInfo) external view virtual returns (bool) {
+  function isActionActive(ActionInfo calldata actionInfo) external view virtual returns (bool) {
     return
       block.timestamp <= approvalEndTime(actionInfo) && (isFixedLengthApprovalPeriod || !isActionApproved(actionInfo));
   }

--- a/src/strategies/LlamaRelativeQuorum.sol
+++ b/src/strategies/LlamaRelativeQuorum.sol
@@ -40,6 +40,9 @@ contract LlamaRelativeQuorum is ILlamaStrategy, Initializable {
   // ======== Errors ========
   // ========================
 
+  /// @dev Only callable by a Llama instance's core contract.
+  error OnlyLlamaCore();
+
   /// @dev The action cannot be canceled if it's already in a terminal state.
   /// @param currentState The current state of the action.
   error CannotCancelInState(ActionState currentState);
@@ -197,6 +200,8 @@ contract LlamaRelativeQuorum is ILlamaStrategy, Initializable {
 
   /// @inheritdoc ILlamaStrategy
   function validateActionCreation(ActionInfo calldata actionInfo) external {
+    if (msg.sender != address(llamaCore)) revert OnlyLlamaCore();
+
     LlamaPolicy llamaPolicy = policy; // Reduce SLOADs.
     uint256 approvalPolicySupply = llamaPolicy.getRoleSupplyAsNumberOfHolders(approvalRole);
     if (approvalPolicySupply == 0) revert RoleHasZeroSupply(approvalRole);
@@ -273,7 +278,7 @@ contract LlamaRelativeQuorum is ILlamaStrategy, Initializable {
   // -------- When Determining Action State --------
 
   /// @inheritdoc ILlamaStrategy
-  function isActive(ActionInfo calldata actionInfo) external view returns (bool) {
+  function isActionActive(ActionInfo calldata actionInfo) external view returns (bool) {
     return
       block.timestamp <= approvalEndTime(actionInfo) && (isFixedLengthApprovalPeriod || !isActionApproved(actionInfo));
   }

--- a/test/mock/MockPoorlyImplementedStrategy.sol
+++ b/test/mock/MockPoorlyImplementedStrategy.sol
@@ -236,7 +236,7 @@ contract MockPoorlyImplementedAbsolutePeerReview is ILlamaStrategy, Initializabl
   // -------- When Determining Action State --------
 
   /// @inheritdoc ILlamaStrategy
-  function isActive(ActionInfo calldata actionInfo) external view returns (bool) {
+  function isActionActive(ActionInfo calldata actionInfo) external view returns (bool) {
     return
       block.timestamp <= approvalEndTime(actionInfo) && (isFixedLengthApprovalPeriod || !isActionApproved(actionInfo));
   }

--- a/test/strategies/LlamaRelativeQuorum.t.sol
+++ b/test/strategies/LlamaRelativeQuorum.t.sol
@@ -836,6 +836,16 @@ contract ValidateActionCreation is LlamaRelativeQuorumTest {
     assertEq(LlamaRelativeQuorum(address(testStrategy)).actionDisapprovalSupply(actionInfo.id), _numberOfPolicies);
   }
 
+  function test_OnlyLlamaCoreCanValidate(uint256 _numberOfPolicies) external {
+    _numberOfPolicies = bound(_numberOfPolicies, 2, 100);
+    ILlamaStrategy testStrategy = deployTestStrategy();
+    generateAndSetRoleHolders(_numberOfPolicies);
+    ActionInfo memory actionInfo = createAction(testStrategy);
+
+    vm.expectRevert(LlamaRelativeQuorum.OnlyLlamaCore.selector);
+    LlamaRelativeQuorum(address(testStrategy)).validateActionCreation(actionInfo);
+  }
+
   function test_CalculateSupplyWhenActionCreatorHasRole(uint256 _numberOfPolicies, uint256 _creatorQuantity) external {
     _numberOfPolicies = bound(_numberOfPolicies, 2, 100);
     _creatorQuantity = bound(_creatorQuantity, 1, 1000);


### PR DESCRIPTION
**Motivation:**

This PR addresses C4 finding: https://github.com/code-423n4/2023-06-llama-findings/issues/62

Closes #376. Closes #381.

**Modifications:**

Confirmed that `validateActionCreation` in `LlamaRelativeQuorum` is the only non-view function in any of the three strategies. Protected this function to ensure it can only be called by `LlamaCore`.

**Result:**

Without this fix any action created using the `LlamaRelativeQuorum` strategy could have its approval and disapproval policy supplies updated at any time.
