### PR TITLE
refactor: rename RoleCheckpoints to PolicyholderCheckpoints

### DIFF
--- a/src/LlamaPolicy.sol
+++ b/src/LlamaPolicy.sol
@@ -6,7 +6,7 @@ import {Clones} from "@openzeppelin/proxy/Clones.sol";
 import {LibString} from "@solady/utils/LibString.sol";
 
 import {ILlamaPolicyMetadata} from "src/interfaces/ILlamaPolicyMetadata.sol";
-import {RoleCheckpoints} from "src/lib/RoleCheckpoints.sol";
+import {PolicyholderCheckpoints} from "src/lib/PolicyholderCheckpoints.sol";
 import {SupplyCheckpoints} from "src/lib/SupplyCheckpoints.sol";
 import {ERC721NonTransferableMinimalProxy} from "src/lib/ERC721NonTransferableMinimalProxy.sol";
 import {LlamaUtils} from "src/lib/LlamaUtils.sol";
@@ -22,7 +22,7 @@ import {LlamaFactory} from "src/LlamaFactory.sol";
 /// policyholder and has roles assigned to `create`, `approve` and `disapprove` actions.
 /// @dev The roles and permissions determine how the policyholder can interact with the Llama core contract.
 contract LlamaPolicy is ERC721NonTransferableMinimalProxy {
-  using RoleCheckpoints for RoleCheckpoints.History;
+  using PolicyholderCheckpoints for PolicyholderCheckpoints.History;
   using SupplyCheckpoints for SupplyCheckpoints.History;
 
   // ======================================
@@ -118,7 +118,7 @@ contract LlamaPolicy is ERC721NonTransferableMinimalProxy {
   /// @dev Checkpoints a token ID's "balance" (quantity) of a given role. The quantity of the
   /// role is how much quantity the role-holder gets when approving/disapproving (regardless of
   /// strategy).
-  mapping(uint256 tokenId => mapping(uint8 role => RoleCheckpoints.History)) internal roleBalanceCkpts;
+  mapping(uint256 tokenId => mapping(uint8 role => PolicyholderCheckpoints.History)) internal roleBalanceCkpts;
 
   /// @notice Returns `true` if the role can create actions with the given permission ID.
   mapping(uint8 role => mapping(bytes32 permissionId => bool)) public canCreateAction;
@@ -298,7 +298,7 @@ contract LlamaPolicy is ERC721NonTransferableMinimalProxy {
   function roleBalanceCheckpoints(address policyholder, uint8 role)
     external
     view
-    returns (RoleCheckpoints.History memory)
+    returns (PolicyholderCheckpoints.History memory)
   {
     uint256 tokenId = _tokenId(policyholder);
     return roleBalanceCkpts[tokenId][role];
@@ -318,7 +318,7 @@ contract LlamaPolicy is ERC721NonTransferableMinimalProxy {
   function roleBalanceCheckpoints(address policyholder, uint8 role, uint256 start, uint256 end)
     external
     view
-    returns (RoleCheckpoints.History memory)
+    returns (PolicyholderCheckpoints.History memory)
   {
     if (start > end) revert InvalidIndices();
     uint256 checkpointsLength = roleBalanceCkpts[_tokenId(policyholder)][role]._checkpoints.length;
@@ -326,11 +326,11 @@ contract LlamaPolicy is ERC721NonTransferableMinimalProxy {
 
     uint256 tokenId = _tokenId(policyholder);
     uint256 sliceLength = end - start;
-    RoleCheckpoints.Checkpoint[] memory checkpoints = new RoleCheckpoints.Checkpoint[](sliceLength);
+    PolicyholderCheckpoints.Checkpoint[] memory checkpoints = new PolicyholderCheckpoints.Checkpoint[](sliceLength);
     for (uint256 i = start; i < end; i = LlamaUtils.uncheckedIncrement(i)) {
       checkpoints[i - start] = roleBalanceCkpts[tokenId][role]._checkpoints[i];
     }
-    return RoleCheckpoints.History(checkpoints);
+    return PolicyholderCheckpoints.History(checkpoints);
   }
 
   /// @notice Returns all supply checkpoints for the given role between `start` and

--- a/src/lib/PolicyholderCheckpoints.sol
+++ b/src/lib/PolicyholderCheckpoints.sol
@@ -8,7 +8,7 @@ import {LlamaUtils} from "src/lib/LlamaUtils.sol";
  * @dev This library defines the `History` struct, for checkpointing values as they change at different points in
  * time, and later looking up past values by block timestamp.
  *
- * To create a history of checkpoints define a variable type `RoleCheckpoints.History` in your contract, and store a new
+ * To create a history of checkpoints define a variable type `PolicyholderCheckpoints.History` in your contract, and store a new
  * checkpoint for the current transaction timestamp using the {push} function.
  *
  * @dev This was created by modifying then running the OpenZeppelin `Checkpoints.js` script, which generated a version
@@ -17,7 +17,7 @@ import {LlamaUtils} from "src/lib/LlamaUtils.sol";
  * the OpenZeppelin versions at the same commit. We disable forge-fmt for this file to simplify diffing against the
  * original OpenZeppelin version: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d00acef4059807535af0bd0dd0ddf619747a044b/contracts/utils/Checkpoints.sol
  */
-library RoleCheckpoints {
+library PolicyholderCheckpoints {
     struct History {
         Checkpoint[] _checkpoints;
     }
@@ -35,7 +35,7 @@ library RoleCheckpoints {
      * timestamp of checkpoints.
      */
     function getAtProbablyRecentTimestamp(History storage self, uint256 timestamp) internal view returns (uint96) {
-        require(timestamp < block.timestamp, "RoleCheckpoints: timestamp is not in the past");
+        require(timestamp < block.timestamp, "PolicyholderCheckpoints: timestamp is not in the past");
         uint64 _timestamp = LlamaUtils.toUint64(timestamp);
 
         uint256 len = self._checkpoints.length;

--- a/test/LlamaPolicy.t.sol
+++ b/test/LlamaPolicy.t.sol
@@ -13,7 +13,7 @@ import {Roles, LlamaTestSetup} from "test/utils/LlamaTestSetup.sol";
 import {SolarrayLlama} from "test/utils/SolarrayLlama.sol";
 
 import {ILlamaPolicyMetadata} from "src/interfaces/ILlamaPolicyMetadata.sol";
-import {RoleCheckpoints} from "src/lib/RoleCheckpoints.sol";
+import {PolicyholderCheckpoints} from "src/lib/PolicyholderCheckpoints.sol";
 import {
   LlamaPolicyInitializationConfig, PermissionData, RoleHolderData, RolePermissionData
 } from "src/lib/Structs.sol";
@@ -766,7 +766,7 @@ contract SetApprovalForAll is LlamaPolicyTest {
 // ====================================
 // ======== Permission Getters ========
 // ====================================
-// The actual checkpointing logic is tested in `RoleCheckpoints.t.sol` and `SupplyCheckpoints.t.sol`,
+// The actual checkpointing logic is tested in `PolicyholderCheckpoints.t.sol` and `SupplyCheckpoints.t.sol`,
 // so here we just test the logic that's added on top of that.
 
 contract GetQuantity is LlamaPolicyTest {
@@ -928,9 +928,9 @@ contract RoleBalanceCheckpointTest is LlamaPolicyTest {
 
 contract RoleBalanceCheckpoints is RoleBalanceCheckpointTest {
   function test_ReturnsBalanceCheckpoint() public {
-    RoleCheckpoints.History memory rbCheckpoint1 =
+    PolicyholderCheckpoints.History memory rbCheckpoint1 =
       mpPolicy.roleBalanceCheckpoints(arbitraryPolicyholder, uint8(Roles.TestRole1));
-    RoleCheckpoints.History memory rbCheckpoint2 =
+    PolicyholderCheckpoints.History memory rbCheckpoint2 =
       mpPolicy.roleBalanceCheckpoints(newRoleHolder, uint8(Roles.TestRole2));
 
     assertEq(rbCheckpoint1._checkpoints.length, 3);
@@ -958,8 +958,8 @@ contract RoleBalanceCheckpoints is RoleBalanceCheckpointTest {
 }
 
 contract RoleBalanceCheckpointsOverload is RoleBalanceCheckpointTest {
-  function assertEqSlice(RoleCheckpoints.History memory full, uint256 start, uint256 end) internal {
-    RoleCheckpoints.History memory slice =
+  function assertEqSlice(PolicyholderCheckpoints.History memory full, uint256 start, uint256 end) internal {
+    PolicyholderCheckpoints.History memory slice =
       mpPolicy.roleBalanceCheckpoints(arbitraryPolicyholder, uint8(Roles.TestRole1), start, end);
 
     assertEq(slice._checkpoints.length, end - start);
@@ -984,7 +984,7 @@ contract RoleBalanceCheckpointsOverload is RoleBalanceCheckpointTest {
   }
 
   function test_ReturnsSlicesOfCheckpointsArray() public {
-    RoleCheckpoints.History memory rbCheckpoint1 =
+    PolicyholderCheckpoints.History memory rbCheckpoint1 =
       mpPolicy.roleBalanceCheckpoints(arbitraryPolicyholder, uint8(Roles.TestRole1));
 
     assertEq(rbCheckpoint1._checkpoints.length, 3);
@@ -1007,7 +1007,7 @@ contract RoleBalanceCheckpointsOverload is RoleBalanceCheckpointTest {
 
 contract RoleBalanceCheckpointsLength is RoleBalanceCheckpointTest {
   function test_ReturnsTheCorrectLength() public {
-    RoleCheckpoints.History memory checkpoints =
+    PolicyholderCheckpoints.History memory checkpoints =
       mpPolicy.roleBalanceCheckpoints(arbitraryPolicyholder, uint8(Roles.TestRole1));
     uint256 length = mpPolicy.roleBalanceCheckpointsLength(arbitraryPolicyholder, uint8(Roles.TestRole1));
     assertEq(length, checkpoints._checkpoints.length);

--- a/test/RoleCheckpoints.t.sol
+++ b/test/RoleCheckpoints.t.sol
@@ -1,70 +1,70 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-/// @dev Tests in this contract mirror those in OpenZeppelin's RoleCheckpoints.test.js, which is why
+/// @dev Tests in this contract mirror those in OpenZeppelin's PolicyholderCheckpoints.test.js, which is why
 /// the tests are written in a different style than the rest of the tests in this repo (i.e. they
 /// do not follow the "one contract per method" pattern).
-/// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d00acef4059807535af0bd0dd0ddf619747a044b/test/utils/RoleCheckpoints.test.js
+/// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d00acef4059807535af0bd0dd0ddf619747a044b/test/utils/PolicyholderCheckpoints.test.js
 import {Test, console2} from "forge-std/Test.sol";
 
-import {RoleCheckpoints} from "src/lib/RoleCheckpoints.sol";
+import {PolicyholderCheckpoints} from "src/lib/PolicyholderCheckpoints.sol";
 
-/// @dev The RoleCheckpointsMock harness contract has its external functions written according to
+/// @dev The PolicyholderCheckpointsMock harness contract has its external functions written according to
 /// https://github.com/foundry-rs/foundry/pull/3128#issuecomment-1241245086
 /// so that test coverage is captured for the Checkpoints library.
-contract RoleCheckpointsMock {
-  RoleCheckpoints.History private _totalCheckpoints;
+contract PolicyholderCheckpointsMock {
+  PolicyholderCheckpoints.History private _totalCheckpoints;
 
   function printCheckpoints() public view {
     for (uint256 i = 0; i < length(); i++) {
-      RoleCheckpoints.Checkpoint memory ckpt = _totalCheckpoints._checkpoints[i];
+      PolicyholderCheckpoints.Checkpoint memory ckpt = _totalCheckpoints._checkpoints[i];
       console2.log(ckpt.timestamp, ckpt.quantity, ckpt.expiration);
     }
   }
 
   function latest() external view returns (uint256) {
-    uint256 quantity = RoleCheckpoints.latest(_totalCheckpoints);
+    uint256 quantity = PolicyholderCheckpoints.latest(_totalCheckpoints);
     return quantity;
   }
 
   function latestCheckpoint() public view returns (bool, uint256, uint256, uint256) {
     (bool exists, uint256 quantity, uint256 timestamp, uint256 expiration) =
-      RoleCheckpoints.latestCheckpoint(_totalCheckpoints);
+      PolicyholderCheckpoints.latestCheckpoint(_totalCheckpoints);
     return (exists, quantity, timestamp, expiration);
   }
 
   function length() public view returns (uint256) {
-    uint256 numCkpts = RoleCheckpoints.length(_totalCheckpoints);
+    uint256 numCkpts = PolicyholderCheckpoints.length(_totalCheckpoints);
     return numCkpts;
   }
 
   function push(uint256 quantity, uint256 expiration) public returns (uint256, uint256) {
-    (uint256 prevQty, uint256 newQty) = RoleCheckpoints.push(_totalCheckpoints, quantity, expiration);
+    (uint256 prevQty, uint256 newQty) = PolicyholderCheckpoints.push(_totalCheckpoints, quantity, expiration);
     return (prevQty, newQty);
   }
 
   function getAtProbablyRecentTimestamp(uint256 timestamp) public view returns (uint256) {
-    uint256 quantity = RoleCheckpoints.getAtProbablyRecentTimestamp(_totalCheckpoints, timestamp);
+    uint256 quantity = PolicyholderCheckpoints.getAtProbablyRecentTimestamp(_totalCheckpoints, timestamp);
     return quantity;
   }
 }
 
-contract RoleCheckpointsTest is Test {
-  RoleCheckpointsMock checkpoints;
+contract PolicyholderCheckpointsTest is Test {
+  PolicyholderCheckpointsMock checkpoints;
   uint64 DEFAULT_EXPIRATION = type(uint64).max;
 
   function setUp() public virtual {
-    checkpoints = new RoleCheckpointsMock();
+    checkpoints = new PolicyholderCheckpointsMock();
   }
 }
 
 // ====================================
 // ======== OpenZeppelin Tests ========
 // ====================================
-// All tests within this section mirror the tests in OpenZeppelin's RoleCheckpoints.test.js and
+// All tests within this section mirror the tests in OpenZeppelin's PolicyholderCheckpoints.test.js and
 // therefore do not account for checkpoint expiration.
 
-contract WithoutCheckpointsWithoutExpiration is RoleCheckpointsTest {
+contract WithoutCheckpointsWithoutExpiration is PolicyholderCheckpointsTest {
   error UnsafeCast(uint256 n);
 
   function test_ReturnsZeroAsLatestValue() public {
@@ -96,13 +96,13 @@ contract WithoutCheckpointsWithoutExpiration is RoleCheckpointsTest {
   }
 }
 
-contract WithCheckpointsWithoutExpiration is RoleCheckpointsTest {
+contract WithCheckpointsWithoutExpiration is PolicyholderCheckpointsTest {
   uint256 t0;
   uint256 t1;
   uint256 t2;
 
   function setUp() public override {
-    RoleCheckpointsTest.setUp();
+    PolicyholderCheckpointsTest.setUp();
 
     vm.warp(block.timestamp + 1);
     t0 = block.timestamp;
@@ -139,12 +139,12 @@ contract WithCheckpointsWithoutExpiration is RoleCheckpointsTest {
   }
 
   function test_Lookup_ProbablyRecentTimestamp_RevertIf_BlockTimestampEqualsCurrentTimestamp() public {
-    vm.expectRevert("RoleCheckpoints: timestamp is not in the past");
+    vm.expectRevert("PolicyholderCheckpoints: timestamp is not in the past");
     checkpoints.getAtProbablyRecentTimestamp(block.timestamp);
   }
 
   function test_Lookup_ProbablyRecentTimestamp_RevertIf_BlockTimestampGreaterThanCurrentTimestamp() public {
-    vm.expectRevert("RoleCheckpoints: timestamp is not in the past");
+    vm.expectRevert("PolicyholderCheckpoints: timestamp is not in the past");
     checkpoints.getAtProbablyRecentTimestamp(block.timestamp + 1);
   }
 
@@ -167,7 +167,7 @@ contract WithCheckpointsWithoutExpiration is RoleCheckpointsTest {
 // ===========================
 // Modification of the above tests to account for checkpoint expiration.
 
-contract WithoutCheckpointsWithExpiration is RoleCheckpointsTest {
+contract WithoutCheckpointsWithExpiration is PolicyholderCheckpointsTest {
   function test_ReturnsZeroAsLatestValue() public {
     assertEq(checkpoints.latest(), 0);
 
@@ -179,13 +179,13 @@ contract WithoutCheckpointsWithExpiration is RoleCheckpointsTest {
   }
 }
 
-contract WithCheckpointsWithExpiration is RoleCheckpointsTest {
+contract WithCheckpointsWithExpiration is PolicyholderCheckpointsTest {
   uint256 t0;
   uint256 t1;
   uint256 t2;
 
   function setUp() public override {
-    RoleCheckpointsTest.setUp();
+    PolicyholderCheckpointsTest.setUp();
 
     vm.warp(block.timestamp + 1);
     t0 = block.timestamp;
@@ -213,12 +213,12 @@ contract WithCheckpointsWithExpiration is RoleCheckpointsTest {
   }
 
   function test_Lookup_ProbablyRecentTimestamp_RevertIf_BlockTimestampEqualsCurrentTimestamp() public {
-    vm.expectRevert("RoleCheckpoints: timestamp is not in the past");
+    vm.expectRevert("PolicyholderCheckpoints: timestamp is not in the past");
     checkpoints.getAtProbablyRecentTimestamp(block.timestamp);
   }
 
   function test_Lookup_ProbablyRecentTimestamp_RevertIf_BlockTimestampGreaterThanCurrentTimestamp() public {
-    vm.expectRevert("RoleCheckpoints: timestamp is not in the past");
+    vm.expectRevert("PolicyholderCheckpoints: timestamp is not in the past");
     checkpoints.getAtProbablyRecentTimestamp(block.timestamp + 1);
   }
 

--- a/test/script/CreateAction.t.sol
+++ b/test/script/CreateAction.t.sol
@@ -8,7 +8,7 @@ import {stdJson} from "forge-std/StdJson.sol";
 import {LlamaAccount} from "src/accounts/LlamaAccount.sol";
 import {Action, ActionInfo} from "src/lib/Structs.sol";
 import {ActionState} from "src/lib/Enums.sol";
-import {RoleCheckpoints} from "src/lib/RoleCheckpoints.sol";
+import {PolicyholderCheckpoints} from "src/lib/PolicyholderCheckpoints.sol";
 import {LlamaCore} from "src/LlamaCore.sol";
 import {LlamaExecutor} from "src/LlamaExecutor.sol";
 import {LlamaFactory} from "src/LlamaFactory.sol";
@@ -236,8 +236,9 @@ contract Run is CreateActionTest {
 
     address initRoleHolder = makeAddr("actionCreatorAaron");
     assertEq(policy.hasRole(initRoleHolder, ACTION_CREATOR_ROLE_ID), true);
-    RoleCheckpoints.History memory balances = policy.roleBalanceCheckpoints(initRoleHolder, ACTION_CREATOR_ROLE_ID);
-    RoleCheckpoints.Checkpoint memory checkpoint = balances._checkpoints[0];
+    PolicyholderCheckpoints.History memory balances =
+      policy.roleBalanceCheckpoints(initRoleHolder, ACTION_CREATOR_ROLE_ID);
+    PolicyholderCheckpoints.Checkpoint memory checkpoint = balances._checkpoints[0];
     assertEq(checkpoint.expiration, type(uint64).max);
     assertEq(checkpoint.quantity, 1);
   }

--- a/test/script/DeployLlama.t.sol
+++ b/test/script/DeployLlama.t.sol
@@ -8,7 +8,7 @@ import {DeployLlama} from "script/DeployLlama.s.sol";
 
 import {LlamaAccount} from "src/accounts/LlamaAccount.sol";
 import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
-import {RoleCheckpoints} from "src/lib/RoleCheckpoints.sol";
+import {PolicyholderCheckpoints} from "src/lib/PolicyholderCheckpoints.sol";
 import {PermissionData} from "src/lib/Structs.sol";
 import {LlamaCore} from "src/LlamaCore.sol";
 import {LlamaFactory} from "src/LlamaFactory.sol";
@@ -140,8 +140,8 @@ contract Run is DeployLlamaTest {
     address initRoleHolder = makeAddr("randomLogicAddress");
     uint8 approverRoleId = 2;
     assertEq(rootPolicy.hasRole(initRoleHolder, approverRoleId), true);
-    RoleCheckpoints.History memory balances = rootPolicy.roleBalanceCheckpoints(initRoleHolder, approverRoleId);
-    RoleCheckpoints.Checkpoint memory checkpoint = balances._checkpoints[0];
+    PolicyholderCheckpoints.History memory balances = rootPolicy.roleBalanceCheckpoints(initRoleHolder, approverRoleId);
+    PolicyholderCheckpoints.Checkpoint memory checkpoint = balances._checkpoints[0];
     assertEq(checkpoint.expiration, type(uint64).max);
     assertEq(checkpoint.quantity, 1);
 


### PR DESCRIPTION
**Motivation:**

Closes https://github.com/llamaxyz/llama/issues/427

**Modifications:**

Renames the `RoleCheckpoints` library to `PolicyholderCheckpoints` for clarity.

**Result:**

No functionality changes, just naming changings
