### PR TITLE
chore: update deploy instance script to use `INSTANCE_CONFIG_FILE` env variable

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ run-script script_name flags='' sig='' args='':
     -vvvv {{flags}}
   mv _test test
 
-run-deploy-instance-script flags: (run-script 'DeployLlamaInstance' flags '--sig "run(address,string)"' '$SCRIPT_DEPLOYER_ADDRESS $INSTANCE_CONFIG_FILE')
+run-deploy-instance-script flags: (run-script 'DeployLlamaInstance' flags '--sig "run(address,string)"' '$SCRIPT_DEPLOYER_ADDRESS "deployLlamaInstance.json"')
 
 dry-run-deploy: (run-script 'DeployLlamaFactory')
 


### PR DESCRIPTION
**Motivation:**

To allow flexible instance deployments, we need to pass the filename to the deployment script.

**Modifications:**

Added the instance configuration filename to the instance deployment script.

**Result:**

Users will be able to deploy new llama instances by changing the instance configuration filename.
