### PR TITLE
docs: update link to Spearbit audit in README and add date to C4 audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ We received two audits from Spearbit and one from Code4rena. You can find links 
 
 - [Llama Spearbit Audit (June 2023)](https://github.com/llamaxyz/llama/blob/main/audits/Llama-Spearbit-Audit.pdf)
 - [Llama Code4rena Audit](https://github.com/llamaxyz/llama/blob/main/audits/Llama-Code4rena-Audit.md)
-- [Llama Spearbit Audit (August 2023)](https://github.com/llamaxyz/llama/blob/main/audits/Llama-Spearbit-Audit-2.md)
+- [Llama Spearbit Audit (August 2023)](https://github.com/llamaxyz/llama/blob/main/audits/Llama-Spearbit-Audit-2.pdf)
 
 ### Bug bounty program
 

--- a/audits/Llama-Code4rena-Audit.md
+++ b/audits/Llama-Code4rena-Audit.md
@@ -1,7 +1,7 @@
 ---
 sponsor: "Llama"
 slug: "2023-06-llama"
-date: "2023-07-⭕⭕"  # the date this report is published to the C4 website
+date: "2023-07-26"  # the date this report is published to the C4 website
 title: "Llama"
 findings: "https://github.com/code-423n4/2023-06-llama-findings/issues"
 contest: 246


### PR DESCRIPTION
**Motivation:**

This PR cleans up a couple audit-related documentation.

**Modifications:**

Use the correct link for the August Spearbit audit and add the published date to the Code4rena audit.

**Result:**

The link to the August Spearbit audit will work and the Code4rena audit will have the published date.
