### PR TITLE
fix: enable absolute strategy deployment on instance creation

### DIFF
--- a/src/strategies/absolute/LlamaAbsoluteStrategyBase.sol
+++ b/src/strategies/absolute/LlamaAbsoluteStrategyBase.sol
@@ -145,7 +145,12 @@ abstract contract LlamaAbsoluteStrategyBase is ILlamaStrategy, Initializable {
     isFixedLengthApprovalPeriod = strategyConfig.isFixedLengthApprovalPeriod;
     approvalPeriod = strategyConfig.approvalPeriod;
 
-    uint256 roleSupply = policy.getPastRoleSupplyAsQuantitySum(strategyConfig.approvalRole, block.timestamp - 1);
+    // If the actions count is 0, then the instance is in the process of being deployed. This means that the current
+    // role supply must be used.
+    uint256 roleSupply = llamaCore.actionsCount() == 0
+      ? policy.getRoleSupplyAsQuantitySum(strategyConfig.approvalRole)
+      : policy.getPastRoleSupplyAsQuantitySum(strategyConfig.approvalRole, block.timestamp - 1);
+
     if (strategyConfig.minApprovals > roleSupply) revert InvalidMinApprovals(strategyConfig.minApprovals);
 
     minApprovals = strategyConfig.minApprovals;

--- a/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
+++ b/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
@@ -6,13 +6,14 @@ import {Test, console2} from "forge-std/Test.sol";
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
 
 import {MockLlamaAbsoluteStrategyBase} from "test/mock/MockLlamaAbsoluteStrategyBase.sol";
+import {MockProtocol} from "test/mock/MockProtocol.sol";
 import {Roles} from "test/utils/LlamaTestSetup.sol";
 import {LlamaStrategyTestSetup} from "test/strategies/LlamaStrategyTestSetup.sol";
 
 import {DeployUtils} from "script/DeployUtils.sol";
 
 import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
-import {ActionInfo, PermissionData} from "src/lib/Structs.sol";
+import {Action, ActionInfo, PermissionData} from "src/lib/Structs.sol";
 import {ActionState} from "src/lib/Enums.sol";
 import {LlamaAbsoluteStrategyBase} from "src/strategies/absolute/LlamaAbsoluteStrategyBase.sol";
 import {LlamaCore} from "src/LlamaCore.sol";
@@ -99,6 +100,30 @@ contract Constructor is LlamaAbsoluteStrategyBaseTest {
 }
 
 contract Initialize is LlamaAbsoluteStrategyBaseTest {
+  function _executeCompleteActionFlow() internal returns (ActionInfo memory actionInfo) {
+    bytes memory data = abi.encodeCall(MockProtocol.pause, (true));
+    vm.prank(actionCreatorAaron);
+    uint256 actionId = mpCore.createAction(uint8(Roles.ActionCreator), mpStrategy1, address(mockProtocol), 0, data, "");
+    actionInfo =
+      ActionInfo(actionId, actionCreatorAaron, uint8(Roles.ActionCreator), mpStrategy1, address(mockProtocol), 0, data);
+    vm.warp(block.timestamp + 1);
+
+    vm.prank(approverAdam);
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo, "");
+
+    vm.prank(approverAlicia);
+    mpCore.castApproval(uint8(Roles.Approver), actionInfo, "");
+
+    vm.warp(block.timestamp + 6 days);
+
+    assertEq(mpStrategy1.isActionApproved(actionInfo), true);
+    mpCore.queueAction(actionInfo);
+
+    vm.warp(block.timestamp + 5 days);
+
+    mpCore.executeAction(actionInfo);
+  }
+
   function testFuzz_SetsStrategyStorageQueuingDuration(uint64 _queuingDuration) public {
     ILlamaStrategy newStrategy = deployTestStrategyAndSetRole(
       DEFAULT_ROLE,
@@ -418,6 +443,87 @@ contract Initialize is LlamaAbsoluteStrategyBaseTest {
     vm.prank(address(mpExecutor));
 
     vm.expectRevert(abi.encodeWithSelector(LlamaAbsoluteStrategyBase.InvalidRole.selector, uint8(Roles.AllHolders)));
+    mpCore.createStrategies(mockLlamaAbsoluteStrategyBaseLogic, DeployUtils.encodeStrategyConfigs(strategyConfigs));
+  }
+
+  function testFuzz_RemovingPoliciesDoesNotAffectStrategyCreation(uint256 _numberOfPolicies) public {
+    // Guarantees that actionCount > 0
+    _executeCompleteActionFlow();
+
+    _numberOfPolicies = bound(_numberOfPolicies, 2, 100);
+    generateAndSetRoleHolders(_numberOfPolicies);
+    uint256 totalQuantity = mpPolicy.getRoleSupplyAsQuantitySum(uint8(Roles.TestRole1));
+    uint256 minApprovals = totalQuantity;
+
+    vm.prank(address(mpExecutor));
+    mpCore.setStrategyLogicAuthorization(mockLlamaAbsoluteStrategyBaseLogic, true);
+
+    LlamaAbsoluteStrategyBase.Config memory strategyConfig = LlamaAbsoluteStrategyBase.Config({
+      approvalPeriod: DEFAULT_APPROVAL_PERIOD,
+      queuingPeriod: DEFAULT_QUEUING_PERIOD,
+      expirationPeriod: DEFAULT_EXPIRATION_PERIOD,
+      minApprovals: toUint96(minApprovals),
+      minDisapprovals: DEFAULT_DISAPPROVALS,
+      isFixedLengthApprovalPeriod: DEFAULT_FIXED_LENGTH_APPROVAL_PERIOD,
+      approvalRole: DEFAULT_ROLE,
+      disapprovalRole: DEFAULT_ROLE,
+      forceApprovalRoles: defaultForceRoles,
+      forceDisapprovalRoles: defaultForceRoles
+    });
+
+    LlamaAbsoluteStrategyBase.Config[] memory strategyConfigs = new LlamaAbsoluteStrategyBase.Config[](1);
+    strategyConfigs[0] = strategyConfig;
+
+    // Set quantity to 0 for `Roles.TestRole1` role holders.
+    for (uint256 i = 0; i < _numberOfPolicies; i++) {
+      address _policyHolder = address(uint160(i + 100));
+      vm.prank(address(mpExecutor));
+      mpPolicy.setRoleHolder(uint8(Roles.TestRole1), _policyHolder, 0, 0);
+    }
+
+    vm.prank(address(mpExecutor));
+    mpCore.createStrategies(mockLlamaAbsoluteStrategyBaseLogic, DeployUtils.encodeStrategyConfigs(strategyConfigs));
+  }
+
+  function testFuzz_RevertIf_QuantityIsIncreasedInPreviousBlock(uint256 _numberOfPolicies) public {
+    // Guarantees that actionCount > 0
+    _executeCompleteActionFlow();
+
+    _numberOfPolicies = bound(_numberOfPolicies, 2, 100);
+    generateAndSetRoleHolders(_numberOfPolicies);
+    uint256 totalQuantity = mpPolicy.getRoleSupplyAsQuantitySum(uint8(Roles.TestRole1));
+    uint256 minApprovals = totalQuantity;
+
+    vm.prank(address(mpExecutor));
+    mpCore.setStrategyLogicAuthorization(mockLlamaAbsoluteStrategyBaseLogic, true);
+
+    LlamaAbsoluteStrategyBase.Config memory strategyConfig = LlamaAbsoluteStrategyBase.Config({
+      approvalPeriod: DEFAULT_APPROVAL_PERIOD,
+      queuingPeriod: DEFAULT_QUEUING_PERIOD,
+      expirationPeriod: DEFAULT_EXPIRATION_PERIOD,
+      minApprovals: toUint96(minApprovals),
+      minDisapprovals: DEFAULT_DISAPPROVALS,
+      isFixedLengthApprovalPeriod: DEFAULT_FIXED_LENGTH_APPROVAL_PERIOD,
+      approvalRole: DEFAULT_ROLE,
+      disapprovalRole: DEFAULT_ROLE,
+      forceApprovalRoles: defaultForceRoles,
+      forceDisapprovalRoles: defaultForceRoles
+    });
+
+    LlamaAbsoluteStrategyBase.Config[] memory strategyConfigs = new LlamaAbsoluteStrategyBase.Config[](1);
+    strategyConfigs[0] = strategyConfig;
+
+    // Set quantity to 0 for `Roles.TestRole1` role holders.
+    for (uint256 i = 0; i < _numberOfPolicies; i++) {
+      address _policyHolder = address(uint160(i + 100));
+      vm.prank(address(mpExecutor));
+      mpPolicy.setRoleHolder(uint8(Roles.TestRole1), _policyHolder, 0, 0);
+    }
+
+    mineBlock();
+
+    vm.prank(address(mpExecutor));
+    vm.expectRevert(abi.encodeWithSelector(LlamaAbsoluteStrategyBase.InvalidMinApprovals.selector, minApprovals));
     mpCore.createStrategies(mockLlamaAbsoluteStrategyBaseLogic, DeployUtils.encodeStrategyConfigs(strategyConfigs));
   }
 }

--- a/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
+++ b/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
@@ -598,6 +598,9 @@ contract Initialize is LlamaAbsoluteStrategyBaseTest {
       mpPolicy.setRoleHolder(uint8(Roles.TestRole1), _policyHolder, 0, 0);
     }
 
+    // Assert that actions count is 0 before creating the strategy
+    assertEq(mpCore.actionsCount(), 0);
+
     vm.prank(address(mpExecutor));
     vm.expectRevert(abi.encodeWithSelector(LlamaAbsoluteStrategyBase.InvalidMinApprovals.selector, minApprovals));
     mpCore.createStrategies(mockLlamaAbsoluteStrategyBaseLogic, DeployUtils.encodeStrategyConfigs(strategyConfigs));

--- a/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
+++ b/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
@@ -556,8 +556,11 @@ contract Initialize is LlamaAbsoluteStrategyBaseTest {
     for (uint256 i = 0; i < _numberOfPolicies; i++) {
       address _policyHolder = address(uint160(i + 100));
       vm.prank(address(mpExecutor));
-      mpPolicy.setRoleHolder(uint8(Roles.TestRole1), _policyHolder, 100, 18_446_744_073_709_551_615);
+      mpPolicy.setRoleHolder(uint8(Roles.TestRole1), _policyHolder, 100, type(uint64).max);
     }
+
+    // Assert that actions count is 0 before creating the strategy
+    assertEq(mpCore.actionsCount(), 0);
 
     vm.prank(address(mpExecutor));
     mpCore.createStrategies(mockLlamaAbsoluteStrategyBaseLogic, DeployUtils.encodeStrategyConfigs(strategyConfigs));

--- a/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
+++ b/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
@@ -446,7 +446,7 @@ contract Initialize is LlamaAbsoluteStrategyBaseTest {
     mpCore.createStrategies(mockLlamaAbsoluteStrategyBaseLogic, DeployUtils.encodeStrategyConfigs(strategyConfigs));
   }
 
-  function testFuzz_RemovingPoliciesDoesNotAffectStrategyCreation(uint256 _numberOfPolicies) public {
+  function testFuzz_NoRevertIfQuantityIsLoweredInSameBlock(uint256 _numberOfPolicies) public {
     // Guarantees that actionCount > 0
     _executeCompleteActionFlow();
 
@@ -485,7 +485,7 @@ contract Initialize is LlamaAbsoluteStrategyBaseTest {
     mpCore.createStrategies(mockLlamaAbsoluteStrategyBaseLogic, DeployUtils.encodeStrategyConfigs(strategyConfigs));
   }
 
-  function testFuzz_RevertIf_QuantityIsIncreasedInPreviousBlock(uint256 _numberOfPolicies) public {
+  function testFuzz_RevertIf_QuantityIsLoweredInPreviousBlock(uint256 _numberOfPolicies) public {
     // Guarantees that actionCount > 0
     _executeCompleteActionFlow();
 
@@ -521,6 +521,43 @@ contract Initialize is LlamaAbsoluteStrategyBaseTest {
     }
 
     mineBlock();
+
+    vm.prank(address(mpExecutor));
+    vm.expectRevert(abi.encodeWithSelector(LlamaAbsoluteStrategyBase.InvalidMinApprovals.selector, minApprovals));
+    mpCore.createStrategies(mockLlamaAbsoluteStrategyBaseLogic, DeployUtils.encodeStrategyConfigs(strategyConfigs));
+  }
+
+  function testFuzz_RevertIfQuantityIsLoweredInSameBlockAndActionCountIsZero(uint256 _numberOfPolicies) public {
+    _numberOfPolicies = bound(_numberOfPolicies, 2, 100);
+    generateAndSetRoleHolders(_numberOfPolicies);
+    uint256 totalQuantity = mpPolicy.getRoleSupplyAsQuantitySum(uint8(Roles.TestRole1));
+    uint256 minApprovals = totalQuantity;
+
+    vm.prank(address(mpExecutor));
+    mpCore.setStrategyLogicAuthorization(mockLlamaAbsoluteStrategyBaseLogic, true);
+
+    LlamaAbsoluteStrategyBase.Config memory strategyConfig = LlamaAbsoluteStrategyBase.Config({
+      approvalPeriod: DEFAULT_APPROVAL_PERIOD,
+      queuingPeriod: DEFAULT_QUEUING_PERIOD,
+      expirationPeriod: DEFAULT_EXPIRATION_PERIOD,
+      minApprovals: toUint96(minApprovals),
+      minDisapprovals: DEFAULT_DISAPPROVALS,
+      isFixedLengthApprovalPeriod: DEFAULT_FIXED_LENGTH_APPROVAL_PERIOD,
+      approvalRole: DEFAULT_ROLE,
+      disapprovalRole: DEFAULT_ROLE,
+      forceApprovalRoles: defaultForceRoles,
+      forceDisapprovalRoles: defaultForceRoles
+    });
+
+    LlamaAbsoluteStrategyBase.Config[] memory strategyConfigs = new LlamaAbsoluteStrategyBase.Config[](1);
+    strategyConfigs[0] = strategyConfig;
+
+    // Set quantity to 0 for `Roles.TestRole1` role holders.
+    for (uint256 i = 0; i < _numberOfPolicies; i++) {
+      address _policyHolder = address(uint160(i + 100));
+      vm.prank(address(mpExecutor));
+      mpPolicy.setRoleHolder(uint8(Roles.TestRole1), _policyHolder, 0, 0);
+    }
 
     vm.prank(address(mpExecutor));
     vm.expectRevert(abi.encodeWithSelector(LlamaAbsoluteStrategyBase.InvalidMinApprovals.selector, minApprovals));


### PR DESCRIPTION
**Motivation:**

This PR enables instances to be configured with absolute strategies on instance creation instead of needing to deploy absolute strategies post instance creation.

**Modifications:**

Added a check in `LlamaAbsoluteStrategyBase.sol` that if the actions count is 0 during initialization (this is only possible if the instance is in the process of being deployed) then the quantity sum is calculated using the current timestamp and not `block.timestamp - 1`.

**Result:**

Instances will be able to be configured with absolute strategies and relative strategies.