### PR TITLE
virtual

### DIFF
--- a/script/DeployLlamaInstance.s.sol
+++ b/script/DeployLlamaInstance.s.sol
@@ -16,7 +16,7 @@ contract DeployLlamaInstance is Script {
   // The core of the deployed Llama instance.
   LlamaCore core;
 
-  function run(address deployer, string memory configFile) public {
+  function run(address deployer, string memory configFile) public virtual {
     // ======== START SAFETY CHECK ========
     // Before deploying the factory, we ensure the bootstrap strategy is configured properly to
     // ensure it can be used to pass actions.


### PR DESCRIPTION
**Motivation:**

In order to make scripting easier and inherit from this deploy script, we are marking the run function as virtual so other scripts can override it.

**Modifications:**

- added virtual to the `run` function in `DeployLlamaInstance.s.sol`

**Result:**

Other scripts can now inherit `DeployLlamaInstance.s.sol` and override its `run` function
