### PR TITLE
refactor: Add virtual to run function in DeployLlamaInstance Script

### DIFF
--- a/script/DeployLlamaInstance.s.sol
+++ b/script/DeployLlamaInstance.s.sol
@@ -20,7 +20,7 @@ contract DeployLlamaInstance is Script {
   // The core of the deployed Llama instance.
   LlamaCore core;
 
-  function run(address deployer, string memory configFile) public {
+  function run(address deployer, string memory configFile) public virtual {
     string memory jsonInput = DeployUtils.readScriptInput(configFile);
     uint256 strategyType = abi.decode(jsonInput.parseRaw(".strategyType"), (uint256));
     if (strategyType > MAX_STRATEGY_TYPE_INDEX) revert InvalidStrategyType();


### PR DESCRIPTION
**Motivation:**

In order to make scripting easier and inherit from this deploy script, we are marking the run function as virtual so other scripts can override it.

**Modifications:**

- added virtual to the `run` function in `DeployLlamaInstance.s.sol`

**Result:**

Other scripts can now inherit `DeployLlamaInstance.s.sol` and override its `run` function
