### PR TITLE
chore: foundry update fmt

### DIFF
--- a/script/DeployLlamaFactory.s.sol
+++ b/script/DeployLlamaFactory.s.sol
@@ -66,11 +66,7 @@ contract DeployLlamaFactory is Script {
     DeployUtils.print(string.concat("  LlamaPolicyMetadataLogic:", vm.toString(address(policyMetadataLogic))));
 
     vm.broadcast();
-    factory = new LlamaFactory(
-      coreLogic,
-      policyLogic,
-      policyMetadataLogic
-    );
+    factory = new LlamaFactory(coreLogic, policyLogic, policyMetadataLogic);
     DeployUtils.print(string.concat("  LlamaFactory:", vm.toString(address(factory))));
 
     vm.broadcast();

--- a/test/LlamaFactory.t.sol
+++ b/test/LlamaFactory.t.sol
@@ -52,11 +52,7 @@ contract LlamaFactoryTest is LlamaTestSetup {
 
 contract Constructor is LlamaFactoryTest {
   function deployLlamaFactory() internal returns (LlamaFactory) {
-    return new LlamaFactory(
-      coreLogic,
-      policyLogic,
-      policyMetadataLogic
-    );
+    return new LlamaFactory(coreLogic, policyLogic, policyMetadataLogic);
   }
 
   function test_SetsLlamaCoreLogicAddress() public {

--- a/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
+++ b/test/strategies/absolute/LlamaAbsoluteStrategyBase.t.sol
@@ -1001,8 +1001,7 @@ contract GetDisapprovalQuantityAt is LlamaAbsoluteStrategyBaseTest {
       DEFAULT_APPROVALS,
       DEFAULT_DISAPPROVALS,
       new uint8[](0),
-      new
-      uint8[](0)
+      new uint8[](0)
     );
 
     vm.warp(_timestamp);

--- a/test/strategies/relative/LlamaRelativeHolderQuorum.t.sol
+++ b/test/strategies/relative/LlamaRelativeHolderQuorum.t.sol
@@ -243,8 +243,7 @@ contract GetApprovalQuantityAt is LlamaRelativeHolderQuorumTest {
       4000,
       2000,
       new uint8[](0),
-      new
-      uint8[](0)
+      new uint8[](0)
     );
 
     vm.warp(_timestamp);
@@ -418,8 +417,7 @@ contract GetDisapprovalQuantityAt is LlamaRelativeHolderQuorumTest {
       4000,
       2000,
       new uint8[](0),
-      new
-      uint8[](0)
+      new uint8[](0)
     );
 
     vm.warp(_timestamp);

--- a/test/strategies/relative/LlamaRelativeQuantityQuorum.t.sol
+++ b/test/strategies/relative/LlamaRelativeQuantityQuorum.t.sol
@@ -245,8 +245,7 @@ contract GetApprovalQuantityAt is LlamaRelativeQuantityQuorumTest {
       4000,
       2000,
       new uint8[](0),
-      new
-      uint8[](0)
+      new uint8[](0)
     );
 
     vm.warp(_timestamp);
@@ -424,8 +423,7 @@ contract GetDisapprovalQuantityAt is LlamaRelativeQuantityQuorumTest {
       4000,
       2000,
       new uint8[](0),
-      new
-      uint8[](0)
+      new uint8[](0)
     );
 
     vm.warp(_timestamp);

--- a/test/strategies/relative/LlamaRelativeUniqueHolderQuorum.t.sol
+++ b/test/strategies/relative/LlamaRelativeUniqueHolderQuorum.t.sol
@@ -243,8 +243,7 @@ contract GetApprovalQuantityAt is LlamaRelativeHolderQuorumTest {
       4000,
       2000,
       new uint8[](0),
-      new
-      uint8[](0)
+      new uint8[](0)
     );
 
     vm.warp(_timestamp);
@@ -473,8 +472,7 @@ contract GetDisapprovalQuantityAt is LlamaRelativeHolderQuorumTest {
       4000,
       2000,
       new uint8[](0),
-      new
-      uint8[](0)
+      new uint8[](0)
     );
 
     vm.warp(_timestamp);

--- a/test/utils/SolarrayLlama.sol
+++ b/test/utils/SolarrayLlama.sol
@@ -212,7 +212,7 @@ library SolarrayLlama {
   {
     uint256 length1 = arr1.length;
     uint256 length2 = arr2.length;
-    newArr = new RoleDescription[](length1+ length2);
+    newArr = new RoleDescription[](length1 + length2);
     for (uint256 i = 0; i < length1;) {
       newArr[i] = arr1[i];
       unchecked {


### PR DESCRIPTION
**Motivation:**

the latest version of foundry updated the linter, so now our CI lint check is failing. This pr simply runs `forge fmt` so that main passes the lint check in CI

**Modifications:**

ran the new formatter on the llama codbase

**Result:**

CI lint checks will pass
