### PR TITLE
fix: update governance script to use more opinionated workflows

### DIFF
--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -215,17 +215,17 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   }
 
   /// @notice Update a role description and set role holders for the updated role.
-  /// @param _updateRoleDescription Role description to update.
+  /// @param roleDescription Role description to update.
   /// @param _setRoleHolders Array of role holders to set.
   function updateRoleDescriptionAndRoleHolders(
-    UpdateRoleDescription calldata _updateRoleDescription,
+    UpdateRoleDescription calldata roleDescription,
     RoleHolderData[] calldata _setRoleHolders
   ) external onlyDelegateCall {
     (, LlamaPolicy policy) = _context();
-    policy.updateRoleDescription(_updateRoleDescription.role, _updateRoleDescription.description);
+    policy.updateRoleDescription(roleDescription.role, roleDescription.description);
 
     for (uint256 i = 0; i < _setRoleHolders.length; i = LlamaUtils.uncheckedIncrement(i)) {
-      if (_setRoleHolders[i].role != _updateRoleDescription.role) revert RoleIsNotUpdatedRole(_setRoleHolders[i].role);
+      if (_setRoleHolders[i].role != roleDescription.role) revert RoleIsNotUpdatedRole(_setRoleHolders[i].role);
     }
     setRoleHolders(_setRoleHolders);
   }

--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.19;
 
 import {Clones} from "@openzeppelin/proxy/Clones.sol";
 
-import {LlamaAccount} from "src/accounts/LlamaAccount.sol";
 import {ILlamaAccount} from "src/interfaces/ILlamaAccount.sol";
 import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
 import {LlamaBaseScript} from "src/llama-scripts/LlamaBaseScript.sol";
@@ -12,7 +11,6 @@ import {PermissionData, RoleHolderData, RolePermissionData} from "src/lib/Struct
 import {RoleDescription} from "src/lib/UDVTs.sol";
 import {LlamaCore} from "src/LlamaCore.sol";
 import {LlamaExecutor} from "src/LlamaExecutor.sol";
-import {LlamaLens} from "src/LlamaLens.sol";
 import {LlamaPolicy} from "src/LlamaPolicy.sol";
 
 /// @title Llama Governance Script
@@ -100,73 +98,54 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   // ======== Common Aggregate Calls ========
   // ========================================
 
+  // TODO: Should this be init role and then assign that role to role holders? Is there a need to init multiple roles
+  // and assign multiple of them?
   /// @notice Initialize new roles and set their holders with the provided data.
-  /// @param description Array of role descriptions to initialize.
+  /// @param descriptions Array of role descriptions to initialize.
   /// @param _setRoleHolders Array of role holders to set.
-  function initRolesAndSetRoleHolders(RoleDescription[] calldata description, RoleHolderData[] calldata _setRoleHolders)
-    external
-    onlyDelegateCall
-  {
-    initRoles(description);
+  function initRolesAndSetRoleHolders(
+    RoleDescription[] calldata descriptions,
+    RoleHolderData[] calldata _setRoleHolders
+  ) external onlyDelegateCall {
+    initRoles(descriptions);
     setRoleHolders(_setRoleHolders);
   }
 
+  // TODO: Should this be init role and then assign permissions only to that role? Is there a need to init multiple
+  // roles and assign permissions to many of them?
   /// @notice Initialize new roles and set their permissions with the provided data.
-  /// @param description Array of role descriptions to initialize.
+  /// @param descriptions Array of role descriptions to initialize.
   /// @param _setRolePermissions Array of role permissions to set.
   function initRolesAndSetRolePermissions(
-    RoleDescription[] calldata description,
+    RoleDescription[] calldata descriptions,
     RolePermissionData[] calldata _setRolePermissions
   ) external onlyDelegateCall {
-    initRoles(description);
+    initRoles(descriptions);
     setRolePermissions(_setRolePermissions);
   }
 
+  // TODO: Should this be init role and then assign only that role to role holders and assign permissions to only that
+  // role? Is there a need to init multiple roles and assign multiple of them? Is there a need to remove roles or
+  // permissions?
   /// @notice Initialize new roles, set their holders, and set their permissions with the provided data.
-  /// @param description Array of role descriptions to initialize.
+  /// @param descriptions Array of role descriptions to initialize.
   /// @param _setRoleHolders Array of role holders to set.
   /// @param _setRolePermissions Array of role permissions to set.
   function initRolesAndHoldersAndPermissions(
-    RoleDescription[] calldata description,
+    RoleDescription[] calldata descriptions,
     RoleHolderData[] calldata _setRoleHolders,
     RolePermissionData[] calldata _setRolePermissions
-  ) external onlyDelegateCall {
-    initRoles(description);
+  ) public onlyDelegateCall {
+    initRoles(descriptions);
     setRoleHolders(_setRoleHolders);
     setRolePermissions(_setRolePermissions);
   }
 
-  /// @notice Create new strategies and set role holders with the provided data.
-  /// @param _createStrategies Struct of data for the `createStrategies` method in `LlamaCore`.
-  /// @param _setRoleHolders Array of role holders to set.
-  function createNewStrategiesAndSetRoleHolders(
-    CreateStrategies calldata _createStrategies,
-    RoleHolderData[] calldata _setRoleHolders
-  ) external onlyDelegateCall {
-    (LlamaCore core,) = _context();
-    core.createStrategies(_createStrategies.llamaStrategyLogic, _createStrategies.strategies);
-    setRoleHolders(_setRoleHolders);
-  }
-
-  /// @notice Create new strategies, initialize new roles and set their holders with the provided data.
-  /// @param _createStrategies Struct of data for the `createStrategies` method in `LlamaCore`.
-  /// @param description Array of role descriptions to initialize.
-  /// @param _setRoleHolders Array of role holders to set.
-  function createStrategiesAndInitRolesAndHolders(
-    CreateStrategies calldata _createStrategies,
-    RoleDescription[] calldata description,
-    RoleHolderData[] calldata _setRoleHolders
-  ) external onlyDelegateCall {
-    (LlamaCore core,) = _context();
-    core.createStrategies(_createStrategies.llamaStrategyLogic, _createStrategies.strategies);
-    initRoles(description);
-    setRoleHolders(_setRoleHolders);
-  }
-
+  // TODO: Turn this into create strategy and only that strategy can be used in these permissions
   /// @notice Create new strategies and set role permissions with the provided data.
   /// @param _createStrategies Struct of data for the `createStrategies` method in `LlamaCore`.
   /// @param _setRolePermissions Array of role permissions to set.
-  function createNewStrategiesAndSetRolePermissions(
+  function createStrategiesAndSetRolePermissions(
     CreateStrategies calldata _createStrategies,
     RolePermissionData[] calldata _setRolePermissions
   ) external onlyDelegateCall {
@@ -175,23 +154,23 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     setRolePermissions(_setRolePermissions);
   }
 
+  // TODO: Create one strategy, one role, and then assign that role to policyholders and assign permissions to that role
+  // with that strategy
   /// @notice Create new strategies, initialize new roles, set their holders and set their permissions with the provided
   /// data.
   /// @param _createStrategies Struct of data for the `createStrategies` method in `LlamaCore`.
-  /// @param description Array of role descriptions to initialize.
+  /// @param descriptions Array of role descriptions to initialize.
   /// @param _setRoleHolders Array of role holders to set.
   /// @param _setRolePermissions Array of role permissions to set.
   function createStrategiesWithRolesAndPermissions(
     CreateStrategies calldata _createStrategies,
-    RoleDescription[] calldata description,
+    RoleDescription[] calldata descriptions,
     RoleHolderData[] calldata _setRoleHolders,
     RolePermissionData[] calldata _setRolePermissions
   ) external onlyDelegateCall {
     (LlamaCore core,) = _context();
     core.createStrategies(_createStrategies.llamaStrategyLogic, _createStrategies.strategies);
-    initRoles(description);
-    setRoleHolders(_setRoleHolders);
-    setRolePermissions(_setRolePermissions);
+    initRolesAndHoldersAndPermissions(descriptions, _setRoleHolders, _setRolePermissions);
   }
 
   /// @notice Revoke policies and update role descriptions with the provided data.
@@ -219,6 +198,7 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     setRoleHolders(_setRoleHolders);
   }
 
+  // TODO: Remove need for user to provide account target
   /// @notice Create Account and set common permissions to allow the given role to approve and transfer tokens.
   /// @param account Account to create.
   /// @param _permissions Array of permissions to set.

--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -39,7 +39,7 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   /// @dev Struct for the data to call the `createStrategies` method in `LlamaCore`.
   struct CreateStrategy {
     ILlamaStrategy llamaStrategyLogic; // Logic contract for the strategies.
-    bytes[] strategies; // Array of configurations to initialize new strategies with.
+    bytes config; // Array of configurations to initialize new strategies with.
   }
 
   /// @dev Struct for the data required to assign a newly intialized role to a policyholder.
@@ -194,12 +194,14 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     CreateStrategy calldata strategy,
     NewStrategyRolesAndPermissionsData[] calldata newStrategyRolesAndPermissionsData
   ) external onlyDelegateCall {
-    if (strategy.strategies.length != 1) revert ArrayLengthMustBeOne();
     (LlamaCore core,) = _context();
-    core.createStrategies(strategy.llamaStrategyLogic, strategy.strategies);
+    bytes[] memory strategies = new bytes[](1);
+    strategies[0] = strategy.config;
+
+    core.createStrategies(strategy.llamaStrategyLogic, strategies);
 
     address strategyAddress = Clones.predictDeterministicAddress(
-      address(strategy.llamaStrategyLogic), keccak256(strategy.strategies[0]), address(core)
+      address(strategy.llamaStrategyLogic), keccak256(strategy.config), address(core)
     );
 
     uint256 length = newStrategyRolesAndPermissionsData.length;

--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -299,6 +299,18 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     setRolePermissions(permissions);
   }
 
+  /// @notice Set strategy logic authorization and create new strategies.
+  /// @param strategyLogic Strategy logic contract to set authorization for.
+  /// @param strategies Array of configurations to initialize new strategies with.
+  function setStrategyLogicAuthAndNewStrategies(ILlamaStrategy strategyLogic, bytes[] calldata strategies)
+    external
+    onlyDelegateCall
+  {
+    (LlamaCore core,) = _context();
+    core.setStrategyLogicAuthorization(strategyLogic, true);
+    core.createStrategies(strategyLogic, strategies);
+  }
+
   // ========================================
   // ======== Batch Core Functions ========
   // ========================================
@@ -340,18 +352,6 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       core.setStrategyAuthorization(strategies[i], authorized);
     }
-  }
-
-  /// @notice Set strategy logic authorization and create new strategies.
-  /// @param strategyLogic Strategy logic contract to set authorization for.
-  /// @param strategies Array of configurations to initialize new strategies with.
-  function setStrategyLogicAuthAndNewStrategies(ILlamaStrategy strategyLogic, bytes[] calldata strategies)
-    external
-    onlyDelegateCall
-  {
-    (LlamaCore core,) = _context();
-    core.setStrategyLogicAuthorization(strategyLogic, true);
-    core.createStrategies(strategyLogic, strategies);
   }
 
   // ========================================

--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -98,35 +98,10 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   // ======== Common Aggregate Calls ========
   // ========================================
 
-  // TODO: Should this be init role and then assign that role to role holders? Is there a need to init multiple roles
-  // and assign multiple of them?
-  /// @notice Initialize new roles and set their holders with the provided data.
-  /// @param descriptions Array of role descriptions to initialize.
-  /// @param _setRoleHolders Array of role holders to set.
-  function initRolesAndSetRoleHolders(
-    RoleDescription[] calldata descriptions,
-    RoleHolderData[] calldata _setRoleHolders
-  ) external onlyDelegateCall {
-    initRoles(descriptions);
-    setRoleHolders(_setRoleHolders);
-  }
+  // TODO: init one role, optionally grant role holders that one role, and optionally assign permissions to that one
+  // role. Removing role holders or permissions is not permitted. Although removal is not allowed passing empty arrays
+  // is allowed to skip the operation.
 
-  // TODO: Should this be init role and then assign permissions only to that role? Is there a need to init multiple
-  // roles and assign permissions to many of them?
-  /// @notice Initialize new roles and set their permissions with the provided data.
-  /// @param descriptions Array of role descriptions to initialize.
-  /// @param _setRolePermissions Array of role permissions to set.
-  function initRolesAndSetRolePermissions(
-    RoleDescription[] calldata descriptions,
-    RolePermissionData[] calldata _setRolePermissions
-  ) external onlyDelegateCall {
-    initRoles(descriptions);
-    setRolePermissions(_setRolePermissions);
-  }
-
-  // TODO: Should this be init role and then assign only that role to role holders and assign permissions to only that
-  // role? Is there a need to init multiple roles and assign multiple of them? Is there a need to remove roles or
-  // permissions?
   /// @notice Initialize new roles, set their holders, and set their permissions with the provided data.
   /// @param descriptions Array of role descriptions to initialize.
   /// @param _setRoleHolders Array of role holders to set.
@@ -141,7 +116,8 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     setRolePermissions(_setRolePermissions);
   }
 
-  // TODO: Turn this into create strategy and only that strategy can be used in these permissions
+  // TODO: Turn this into create strategy and only that strategy can be used in these permissions and hasPermission has
+  // to be true
   /// @notice Create new strategies and set role permissions with the provided data.
   /// @param _createStrategies Struct of data for the `createStrategies` method in `LlamaCore`.
   /// @param _setRolePermissions Array of role permissions to set.
@@ -152,25 +128,6 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     (LlamaCore core,) = _context();
     core.createStrategies(_createStrategies.llamaStrategyLogic, _createStrategies.strategies);
     setRolePermissions(_setRolePermissions);
-  }
-
-  // TODO: Create one strategy, one role, and then assign that role to policyholders and assign permissions to that role
-  // with that strategy
-  /// @notice Create new strategies, initialize new roles, set their holders and set their permissions with the provided
-  /// data.
-  /// @param _createStrategies Struct of data for the `createStrategies` method in `LlamaCore`.
-  /// @param descriptions Array of role descriptions to initialize.
-  /// @param _setRoleHolders Array of role holders to set.
-  /// @param _setRolePermissions Array of role permissions to set.
-  function createStrategiesWithRolesAndPermissions(
-    CreateStrategies calldata _createStrategies,
-    RoleDescription[] calldata descriptions,
-    RoleHolderData[] calldata _setRoleHolders,
-    RolePermissionData[] calldata _setRolePermissions
-  ) external onlyDelegateCall {
-    (LlamaCore core,) = _context();
-    core.createStrategies(_createStrategies.llamaStrategyLogic, _createStrategies.strategies);
-    initRolesAndHoldersAndPermissions(descriptions, _setRoleHolders, _setRolePermissions);
   }
 
   /// @notice Revoke policies and update role descriptions with the provided data.
@@ -184,6 +141,7 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     updateRoleDescriptions(_updateRoleDescriptions);
   }
 
+  // TODO: should we encorce restrictions here?
   /// @notice Revoke policies, update role descriptions, and set role holders with the provided data.
   /// @param _revokePolicies Array of policies to revoke.
   /// @param _updateRoleDescriptions Array of role descriptions to update.

--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 import {Clones} from "@openzeppelin/proxy/Clones.sol";
 
 import {ILlamaAccount} from "src/interfaces/ILlamaAccount.sol";
+import {ILlamaActionGuard} from "src/interfaces/ILlamaActionGuard.sol";
 import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
 import {LlamaUtils} from "src/lib/LlamaUtils.sol";
 import {PermissionData, RoleHolderData, RolePermissionData} from "src/lib/Structs.sol";
@@ -84,9 +85,6 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   // ========================
   // ======== Errors ========
   // ========================
-
-  /// @dev The provided array does not have a length of 1.
-  error ArrayLengthMustBeOne();
 
   /// @dev The call did not succeed.
   /// @param index Index of the arbitrary function being called.
@@ -351,6 +349,18 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     uint256 length = strategies.length;
     for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       core.setStrategyAuthorization(strategies[i], authorized);
+    }
+  }
+
+  /// @notice Set a guard on multiple selectors on a single target.
+  /// @param target The target contract where the `guard` will apply.
+  /// @param selectors An array of selectors to apply the guard to.
+  /// @param guard The guard being applied.
+  function setGuards(address target, bytes4[] calldata selectors, ILlamaActionGuard guard) external onlyDelegateCall {
+    (LlamaCore core,) = _context();
+    uint256 length = selectors.length;
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
+      core.setGuard(target, selectors[i], guard);
     }
   }
 

--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -156,9 +156,12 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     policy.initializeRole(description);
     uint8 initializedRole = policy.numRoles();
 
-    if (newRoleHolders.length > 0) {
-      RoleHolderData[] memory roleHolders = new RoleHolderData[](newRoleHolders.length);
-      for (uint256 i = 0; i < newRoleHolders.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 holdersLength = newRoleHolders.length;
+    uint256 permissionsLength = newRolePermissionData.length;
+
+    if (holdersLength > 0) {
+      RoleHolderData[] memory roleHolders = new RoleHolderData[](holdersLength);
+      for (uint256 i = 0; i < holdersLength; i = LlamaUtils.uncheckedIncrement(i)) {
         if (newRoleHolders[i].quantity == 0) revert RoleQuantityMustBeGreaterThanZero();
         roleHolders[i] = RoleHolderData(
           initializedRole, newRoleHolders[i].policyholder, newRoleHolders[i].quantity, newRoleHolders[i].expiration
@@ -167,9 +170,9 @@ contract LlamaGovernanceScript is LlamaBaseScript {
       setRoleHolders(roleHolders);
     }
 
-    if (newRolePermissionData.length > 0) {
-      RolePermissionData[] memory permissions = new RolePermissionData[](newRolePermissionData.length);
-      for (uint256 i = 0; i < newRolePermissionData.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    if (permissionsLength > 0) {
+      RolePermissionData[] memory permissions = new RolePermissionData[](permissionsLength);
+      for (uint256 i = 0; i < permissionsLength; i = LlamaUtils.uncheckedIncrement(i)) {
         permissions[i] = RolePermissionData(
           initializedRole,
           PermissionData(
@@ -199,8 +202,9 @@ contract LlamaGovernanceScript is LlamaBaseScript {
       address(strategy.llamaStrategyLogic), keccak256(strategy.strategies[0]), address(core)
     );
 
-    RolePermissionData[] memory permissions = new RolePermissionData[](newStrategyRolesAndPermissionsData.length);
-    for (uint256 i = 0; i < newStrategyRolesAndPermissionsData.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = newStrategyRolesAndPermissionsData.length;
+    RolePermissionData[] memory permissions = new RolePermissionData[](length);
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       permissions[i] = RolePermissionData(
         newStrategyRolesAndPermissionsData[i].role,
         PermissionData(
@@ -224,7 +228,8 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     (, LlamaPolicy policy) = _context();
     policy.updateRoleDescription(roleDescription.role, roleDescription.description);
 
-    for (uint256 i = 0; i < _setRoleHolders.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = _setRoleHolders.length;
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       if (_setRoleHolders[i].role != roleDescription.role) revert RoleIsNotUpdatedRole(_setRoleHolders[i].role);
     }
     setRoleHolders(_setRoleHolders);
@@ -246,8 +251,9 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     address accountAddress =
       Clones.predictDeterministicAddress(address(account.accountLogic), keccak256(account.config), address(core));
 
-    RolePermissionData[] memory permissions = new RolePermissionData[](newRolePermissionsData.length);
-    for (uint256 i = 0; i < newRolePermissionsData.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = newRolePermissionsData.length;
+    RolePermissionData[] memory permissions = new RolePermissionData[](length);
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       permissions[i] = RolePermissionData(
         newRolePermissionsData[i].role,
         PermissionData(
@@ -275,8 +281,9 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   ) external onlyDelegateCall {
     (LlamaCore core,) = _context();
     core.setScriptAuthorization(script, authorized);
-    RolePermissionData[] memory permissions = new RolePermissionData[](newRolePermissionsData.length);
-    for (uint256 i = 0; i < newRolePermissionsData.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = newRolePermissionsData.length;
+    RolePermissionData[] memory permissions = new RolePermissionData[](length);
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       permissions[i] = RolePermissionData(
         newRolePermissionsData[i].role,
         PermissionData(
@@ -302,7 +309,8 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     onlyDelegateCall
   {
     (LlamaCore core,) = _context();
-    for (uint256 i = 0; i < strategyLogics.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = strategyLogics.length;
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       core.setStrategyLogicAuthorization(strategyLogics[i], authorized);
     }
   }
@@ -315,7 +323,8 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     onlyDelegateCall
   {
     (LlamaCore core,) = _context();
-    for (uint256 i = 0; i < accountLogics.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = accountLogics.length;
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       core.setAccountLogicAuthorization(accountLogics[i], authorized);
     }
   }
@@ -325,7 +334,8 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   /// @param authorized Boolean to determine whether a strategy is being authorized or unauthorized.
   function setStrategyAuthorizations(ILlamaStrategy[] calldata strategies, bool authorized) external onlyDelegateCall {
     (LlamaCore core,) = _context();
-    for (uint256 i = 0; i < strategies.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = strategies.length;
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       core.setStrategyAuthorization(strategies[i], authorized);
     }
   }
@@ -387,7 +397,8 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   /// @param _revokePolicies Array of policies to revoke.
   function revokePolicies(address[] calldata _revokePolicies) external onlyDelegateCall {
     (, LlamaPolicy policy) = _context();
-    for (uint256 i = 0; i < _revokePolicies.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = _revokePolicies.length;
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       policy.revokePolicy(_revokePolicies[i]);
     }
   }
@@ -396,7 +407,8 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   /// @param roleDescriptions Array of role descriptions to update.
   function updateRoleDescriptions(UpdateRoleDescription[] calldata roleDescriptions) external onlyDelegateCall {
     (, LlamaPolicy policy) = _context();
-    for (uint256 i = 0; i < roleDescriptions.length; i = LlamaUtils.uncheckedIncrement(i)) {
+    uint256 length = roleDescriptions.length;
+    for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       policy.updateRoleDescription(roleDescriptions[i].role, roleDescriptions[i].description);
     }
   }

--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -220,19 +220,19 @@ contract LlamaGovernanceScript is LlamaBaseScript {
 
   /// @notice Update a role description and set role holders for the updated role.
   /// @param roleDescription Role description to update.
-  /// @param _setRoleHolders Array of role holders to set.
+  /// @param roleHolderData Array of role holders to set.
   function updateRoleDescriptionAndRoleHolders(
     UpdateRoleDescription calldata roleDescription,
-    RoleHolderData[] calldata _setRoleHolders
+    RoleHolderData[] calldata roleHolderData
   ) external onlyDelegateCall {
     (, LlamaPolicy policy) = _context();
     policy.updateRoleDescription(roleDescription.role, roleDescription.description);
 
-    uint256 length = _setRoleHolders.length;
+    uint256 length = roleHolderData.length;
     for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
-      if (_setRoleHolders[i].role != roleDescription.role) revert RoleIsNotUpdatedRole(_setRoleHolders[i].role);
+      if (roleHolderData[i].role != roleDescription.role) revert RoleIsNotUpdatedRole(roleHolderData[i].role);
     }
-    setRoleHolders(_setRoleHolders);
+    setRoleHolders(roleHolderData);
   }
 
   /// @notice Create account and grant permissions to one or many roles with the account as a target.
@@ -367,39 +367,36 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   }
 
   /// @notice Batch set role holders with the provided data.
-  /// @param _setRoleHolders Array of role holders to set.
-  function setRoleHolders(RoleHolderData[] memory _setRoleHolders) public onlyDelegateCall {
+  /// @param roleHolderData Array of role holders to set.
+  function setRoleHolders(RoleHolderData[] memory roleHolderData) public onlyDelegateCall {
     (, LlamaPolicy policy) = _context();
-    uint256 length = _setRoleHolders.length;
+    uint256 length = roleHolderData.length;
     for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       policy.setRoleHolder(
-        _setRoleHolders[i].role,
-        _setRoleHolders[i].policyholder,
-        _setRoleHolders[i].quantity,
-        _setRoleHolders[i].expiration
+        roleHolderData[i].role, roleHolderData[i].policyholder, roleHolderData[i].quantity, roleHolderData[i].expiration
       );
     }
   }
 
   /// @notice Batch set role permissions with the provided data.
-  /// @param _setRolePermissions Array of role permissions to set.
-  function setRolePermissions(RolePermissionData[] memory _setRolePermissions) public onlyDelegateCall {
+  /// @param rolePermissionData Array of role permissions to set.
+  function setRolePermissions(RolePermissionData[] memory rolePermissionData) public onlyDelegateCall {
     (, LlamaPolicy policy) = _context();
-    uint256 length = _setRolePermissions.length;
+    uint256 length = rolePermissionData.length;
     for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
       policy.setRolePermission(
-        _setRolePermissions[i].role, _setRolePermissions[i].permissionData, _setRolePermissions[i].hasPermission
+        rolePermissionData[i].role, rolePermissionData[i].permissionData, rolePermissionData[i].hasPermission
       );
     }
   }
 
   /// @notice Batch revoke policies with the provided data.
-  /// @param _revokePolicies Array of policies to revoke.
-  function revokePolicies(address[] calldata _revokePolicies) external onlyDelegateCall {
+  /// @param policies Array of policies to revoke.
+  function revokePolicies(address[] calldata policies) external onlyDelegateCall {
     (, LlamaPolicy policy) = _context();
-    uint256 length = _revokePolicies.length;
+    uint256 length = policies.length;
     for (uint256 i = 0; i < length; i = LlamaUtils.uncheckedIncrement(i)) {
-      policy.revokePolicy(_revokePolicies[i]);
+      policy.revokePolicy(policies[i]);
     }
   }
 

--- a/src/llama-scripts/LlamaGovernanceScript.sol
+++ b/src/llama-scripts/LlamaGovernanceScript.sol
@@ -112,6 +112,7 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   // ========================================
 
   /// @notice Initialize a new role, grant this role to role holders, and grant permissions to this role.
+  /// @dev Permissions can only be granted and not removed.
   /// @param description Role description to initialize.
   /// @param _setRoleHolders Array of role holders to grant the new role.
   /// @param targets Array of targets to use as part of the permissions.
@@ -148,6 +149,7 @@ contract LlamaGovernanceScript is LlamaBaseScript {
   }
 
   /// @notice Create new strategy and grant role permissions using that strategy.
+  /// @dev Permissions can only be granted and not removed.
   /// @param strategy Struct of data for the `createStrategies` method in `LlamaCore`. `strategies` config array
   /// must have a length of 1.
   /// @param roles Array of roles to use as part of the permissions.
@@ -192,7 +194,8 @@ contract LlamaGovernanceScript is LlamaBaseScript {
     setRoleHolders(_setRoleHolders);
   }
 
-  /// @notice Create account and grant permissions to role with the account as a target.
+  /// @notice Create account and grant permissions to multiple roles with the account as a target.
+  /// @dev Permissions can only be granted and not removed.
   /// @param account Configuration of new account.
   /// @param roles Roles to set permissions for.
   /// @param selectors Array of selectors to use as part of the permissions.

--- a/test/llama-scripts/LlamaGovernanceScript.t.sol
+++ b/test/llama-scripts/LlamaGovernanceScript.t.sol
@@ -584,127 +584,114 @@ contract UpdateRoleDescriptionAndRoleHolders is LlamaGovernanceScriptTest {
   }
 }
 
-// contract CreateAccountAndSetRolePermissions is LlamaGovernanceScriptTest {
-//   function test_CreateAccountAndSetRolePermissions() public {
-//     bytes memory config = abi.encode(LlamaAccount.Config({name: "mockAccountERC20"}));
-//     LlamaGovernanceScript.CreateAccounts memory account = LlamaGovernanceScript.CreateAccounts(accountLogic, config);
+contract CreateAccountAndSetRolePermissions is LlamaGovernanceScriptTest {
+  function test_CreateAccountAndSetRolePermissions() public {
+    bytes memory config = abi.encode(LlamaAccount.Config({name: "mockAccountERC20"}));
+    LlamaGovernanceScript.CreateAccounts memory account = LlamaGovernanceScript.CreateAccounts(accountLogic, config);
 
-//     ILlamaAccount accountAddress = lens.computeLlamaAccountAddress(address(accountLogic), config, address(mpCore));
+    ILlamaAccount accountAddress = lens.computeLlamaAccountAddress(address(accountLogic), config, address(mpCore));
 
-//     PermissionData memory permissionData1 =
-//       PermissionData(address(accountAddress), LlamaAccount.batchTransferNativeToken.selector, mpStrategy2);
-//     PermissionData memory permissionData2 =
-//       PermissionData(address(accountAddress), LlamaAccount.batchTransferERC20.selector, mpStrategy2);
-//     PermissionData memory permissionData3 =
-//       PermissionData(address(accountAddress), LlamaAccount.batchApproveERC20.selector, mpStrategy2);
-//     PermissionData memory permissionData4 =
-//       PermissionData(address(accountAddress), LlamaAccount.batchTransferERC721.selector, mpStrategy2);
-//     PermissionData memory permissionData5 =
-//       PermissionData(address(accountAddress), LlamaAccount.batchApproveERC721.selector, mpStrategy2);
-//     PermissionData memory permissionData6 =
-//       PermissionData(address(accountAddress), LlamaAccount.batchApproveOperatorERC721.selector, mpStrategy2);
+    PermissionData memory permissionData1 =
+      PermissionData(address(accountAddress), LlamaAccount.batchTransferNativeToken.selector, mpStrategy2);
+    PermissionData memory permissionData2 =
+      PermissionData(address(accountAddress), LlamaAccount.batchTransferERC20.selector, mpStrategy2);
+    PermissionData memory permissionData3 =
+      PermissionData(address(accountAddress), LlamaAccount.batchApproveERC20.selector, mpStrategy2);
+    PermissionData memory permissionData4 =
+      PermissionData(address(accountAddress), LlamaAccount.batchTransferERC721.selector, mpStrategy2);
+    PermissionData memory permissionData5 =
+      PermissionData(address(accountAddress), LlamaAccount.batchApproveERC721.selector, mpStrategy2);
+    PermissionData memory permissionData6 =
+      PermissionData(address(accountAddress), LlamaAccount.batchApproveOperatorERC721.selector, mpStrategy2);
 
-//     RolePermissionData[] memory _permissions = new RolePermissionData[](6);
-//     _permissions[0] = RolePermissionData(uint8(Roles.ActionCreator), permissionData1, true);
-//     _permissions[1] = RolePermissionData(uint8(Roles.ActionCreator), permissionData2, true);
-//     _permissions[2] = RolePermissionData(uint8(Roles.ActionCreator), permissionData3, true);
-//     _permissions[3] = RolePermissionData(uint8(Roles.ActionCreator), permissionData4, true);
-//     _permissions[4] = RolePermissionData(uint8(Roles.ActionCreator), permissionData5, true);
-//     _permissions[5] = RolePermissionData(uint8(Roles.ActionCreator), permissionData6, true);
+    RolePermissionData[] memory _permissions = new RolePermissionData[](6);
+    _permissions[0] = RolePermissionData(uint8(Roles.ActionCreator), permissionData1, true);
+    _permissions[1] = RolePermissionData(uint8(Roles.ActionCreator), permissionData2, true);
+    _permissions[2] = RolePermissionData(uint8(Roles.ActionCreator), permissionData3, true);
+    _permissions[3] = RolePermissionData(uint8(Roles.ActionCreator), permissionData4, true);
+    _permissions[4] = RolePermissionData(uint8(Roles.ActionCreator), permissionData5, true);
+    _permissions[5] = RolePermissionData(uint8(Roles.ActionCreator), permissionData6, true);
 
-//     bytes memory data =
-//       abi.encodeWithSelector(LlamaGovernanceScript.createAccountAndSetRolePermissions.selector, account,
-// _permissions);
+    LlamaGovernanceScript.NewRolePermissionsData[] memory newRolePermissionsData =
+      new LlamaGovernanceScript.NewRolePermissionsData[](6);
 
-//     (ActionInfo memory actionInfo) = _createAndApproveAndQueueAction(data);
+    for (uint256 i = 0; i < newRolePermissionsData.length; i = LlamaUtils.uncheckedIncrement(i)) {
+      newRolePermissionsData[i] = LlamaGovernanceScript.NewRolePermissionsData(
+        _permissions[i].role,
+        LlamaGovernanceScript.SelectorStrategy(
+          _permissions[i].permissionData.selector, _permissions[i].permissionData.strategy
+        )
+      );
+    }
 
-//     vm.expectEmit();
-//     emit AccountCreated(accountAddress, accountLogic, config);
+    bytes memory data = abi.encodeWithSelector(
+      LlamaGovernanceScript.createAccountAndSetRolePermissions.selector, account, newRolePermissionsData
+    );
 
-//     vm.expectEmit();
-//     emit RolePermissionAssigned(
-//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData1), permissionData1, true
-//     );
+    (ActionInfo memory actionInfo) = _createAndApproveAndQueueAction(data);
 
-//     vm.expectEmit();
-//     emit RolePermissionAssigned(
-//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData2), permissionData2, true
-//     );
+    vm.expectEmit();
+    emit AccountCreated(accountAddress, accountLogic, config);
 
-//     vm.expectEmit();
-//     emit RolePermissionAssigned(
-//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData3), permissionData3, true
-//     );
+    vm.expectEmit();
+    emit RolePermissionAssigned(
+      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData1), permissionData1, true
+    );
 
-//     vm.expectEmit();
-//     emit RolePermissionAssigned(
-//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData4), permissionData4, true
-//     );
+    vm.expectEmit();
+    emit RolePermissionAssigned(
+      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData2), permissionData2, true
+    );
 
-//     vm.expectEmit();
-//     emit RolePermissionAssigned(
-//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData5), permissionData5, true
-//     );
+    vm.expectEmit();
+    emit RolePermissionAssigned(
+      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData3), permissionData3, true
+    );
 
-//     vm.expectEmit();
-//     emit RolePermissionAssigned(
-//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData6), permissionData6, true
-//     );
+    vm.expectEmit();
+    emit RolePermissionAssigned(
+      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData4), permissionData4, true
+    );
 
-//     mpCore.executeAction(actionInfo);
-//   }
+    vm.expectEmit();
+    emit RolePermissionAssigned(
+      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData5), permissionData5, true
+    );
 
-//   function test_RevertsIf_TargetIsNotAccount(address notAccount) public {
-//     bytes memory config = abi.encode(LlamaAccount.Config({name: "mockAccountERC20"}));
-//     LlamaGovernanceScript.CreateAccounts memory account = LlamaGovernanceScript.CreateAccounts(accountLogic, config);
+    vm.expectEmit();
+    emit RolePermissionAssigned(
+      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData6), permissionData6, true
+    );
 
-//     ILlamaAccount accountAddress = lens.computeLlamaAccountAddress(address(accountLogic), config, address(mpCore));
+    mpCore.executeAction(actionInfo);
+  }
+}
 
-//     vm.assume(notAccount != address(accountAddress));
+contract SetScriptAuthAndSetPermissions is LlamaGovernanceScriptTest {
+  function test_SetScriptAuthAndSetPermissions(address script, bool authorized, bytes4[] calldata selectors) public {
+    ILlamaStrategy[] memory strategies = new ILlamaStrategy[](selectors.length);
 
-//     PermissionData memory permissionData =
-//       PermissionData(notAccount, LlamaAccount.batchTransferNativeToken.selector, mpStrategy2);
+    bytes memory data = abi.encodeWithSelector(
+      LlamaGovernanceScript.setScriptAuthAndSetPermissions.selector,
+      script,
+      authorized,
+      uint8(Roles.ActionCreator),
+      selectors,
+      strategies
+    );
+    (ActionInfo memory actionInfo) = _createAndApproveAndQueueAction(data);
 
-//     RolePermissionData[] memory _permissions = new RolePermissionData[](1);
-//     _permissions[0] = RolePermissionData(uint8(Roles.ActionCreator), permissionData, true);
-
-//     bytes memory data =
-//       abi.encodeWithSelector(LlamaGovernanceScript.createAccountAndSetRolePermissions.selector, account,
-// _permissions);
-
-//     (ActionInfo memory actionInfo) = _createAndApproveAndQueueAction(data);
-
-//     vm.expectRevert(); // reverts with FailedActionExecution and does not reach the TargetIsNotAccount error
-
-//     mpCore.executeAction(actionInfo);
-//   }
-// }
-
-// contract SetScriptAuthAndSetPermissions is LlamaGovernanceScriptTest {
-//   function test_SetScriptAuthAndSetPermissions(address script, bool authorized, bytes4[] calldata selectors) public {
-//     ILlamaStrategy[] memory strategies = new ILlamaStrategy[](selectors.length);
-
-//     bytes memory data = abi.encodeWithSelector(
-//       LlamaGovernanceScript.setScriptAuthAndSetPermissions.selector,
-//       script,
-//       authorized,
-//       uint8(Roles.ActionCreator),
-//       selectors,
-//       strategies
-//     );
-//     (ActionInfo memory actionInfo) = _createAndApproveAndQueueAction(data);
-
-//     vm.expectEmit();
-//     emit ScriptAuthorizationSet(script, authorized);
-//     for (uint256 i = 0; i < selectors.length; i++) {
-//       PermissionData memory permissionData = PermissionData(script, selectors[i], strategies[i]);
-//       bytes32 permissionId = lens.computePermissionId(permissionData);
-//       vm.expectEmit();
-//       emit RolePermissionAssigned(uint8(Roles.ActionCreator), permissionId, permissionData, authorized);
-//     }
-//     mpCore.executeAction(actionInfo);
-//   }
-// }
+    vm.expectEmit();
+    emit ScriptAuthorizationSet(script, authorized);
+    for (uint256 i = 0; i < selectors.length; i++) {
+      PermissionData memory permissionData = PermissionData(script, selectors[i], strategies[i]);
+      bytes32 permissionId = lens.computePermissionId(permissionData);
+      vm.expectEmit();
+      emit RolePermissionAssigned(uint8(Roles.ActionCreator), permissionId, permissionData, authorized);
+    }
+    mpCore.executeAction(actionInfo);
+  }
+}
 
 contract SetStrategyLogicAuthorizations is LlamaGovernanceScriptTest {
   function test_setStrategyLogicAuthorizations(bool authorized) public {

--- a/test/llama-scripts/LlamaGovernanceScript.t.sol
+++ b/test/llama-scripts/LlamaGovernanceScript.t.sol
@@ -38,62 +38,44 @@ contract LlamaGovernanceScriptTest is LlamaTestSetup {
   LlamaGovernanceScript govScript;
 
   bytes4 public constant AGGREGATE_SELECTOR = LlamaGovernanceScript.aggregate.selector;
-  bytes4 public constant INIT_ROLES_AND_SET_ROLE_HOLDERS_SELECTOR =
-    LlamaGovernanceScript.initRolesAndSetRoleHolders.selector;
-  bytes4 public constant INITIALIZE_ROLES_AND_SET_ROLE_PERMISSIONS_SELECTOR =
-    LlamaGovernanceScript.initRolesAndSetRolePermissions.selector;
-  bytes4 public constant INIT_ROLES_AND_HOLDERS_AND_PERMISSIONS_SELECTOR =
-    LlamaGovernanceScript.initRolesAndHoldersAndPermissions.selector;
-  bytes4 public constant CREATE_NEW_STRATEGIES_AND_SET_ROLE_HOLDERS_SELECTOR =
-    LlamaGovernanceScript.createNewStrategiesAndSetRoleHolders.selector;
-  bytes4 public constant CREATE_STRATEGIES_AND_INIT_ROLES_AND_HOLDERS_SELECTOR =
-    LlamaGovernanceScript.createStrategiesAndInitRolesAndHolders.selector;
-  bytes4 public constant CREATE_NEW_STRATEGIES_AND_SET_ROLE_PERMISSIONS_SELECTOR =
-    LlamaGovernanceScript.createNewStrategiesAndSetRolePermissions.selector;
-  bytes4 public constant CREATE_STRATEGIES_WITH_ROLES_AND_PERMISSIONS_SELECTOR =
-    LlamaGovernanceScript.createStrategiesWithRolesAndPermissions.selector;
-  bytes4 public constant REVOKE_POLICIES_AND_UPDATE_ROLE_DESCRIPTIONS_SELECTOR =
-    LlamaGovernanceScript.revokePoliciesAndUpdateRoleDescriptions.selector;
-  bytes4 public constant REVOKE_POLICIES_AND_SET_ROLE_DESCS_AND_HOLDERS_SELECTOR =
-    LlamaGovernanceScript.revokePoliciesAndSetRoleDescsAndHolders.selector;
+  bytes4 public constant INIT_ROLE_AND_HOLDERS_AND_PERMISSIONS_SELECTOR =
+    LlamaGovernanceScript.initRoleAndHoldersAndPermissions.selector;
+  bytes4 public constant CREATE_STRATEGY_AND_SET_ROLE_PERMISSIONS_SELECTOR =
+    LlamaGovernanceScript.createStrategyAndSetRolePermissions.selector;
+  bytes4 public constant UPDATE_ROLE_DESCRIPTION_AND_ROLE_HOLDERS_SELECTOR =
+    LlamaGovernanceScript.updateRoleDescriptionAndRoleHolders.selector;
+  bytes4 public constant CREATE_ACCOUNT_AND_SET_ROLE_PERMISSIONS_SELECTOR =
+    LlamaGovernanceScript.createAccountAndSetRolePermissions.selector;
+  bytes4 public constant SET_SCRIPT_AUTH_AND_SET_PERMISSIONS_SELECTOR =
+    LlamaGovernanceScript.setScriptAuthAndSetPermissions.selector;
+  bytes4 public constant SET_STRATEGY_LOGIC_AUTHORIZATIONS_SELECTOR =
+    LlamaGovernanceScript.setStrategyLogicAuthorizations.selector;
+  bytes4 public constant SET_ACCOUNT_LOGIC_AUTHORIZATIONS_SELECTOR =
+    LlamaGovernanceScript.setAccountLogicAuthorizations.selector;
+  bytes4 public constant SET_STRATEGY_AUTHORIZATIONS_SELECTOR = LlamaGovernanceScript.setStrategyAuthorizations.selector;
+  bytes4 public constant SET_STRATEGY_LOGIC_AUTH_AND_NEW_STRATEGIES_SELECTOR =
+    LlamaGovernanceScript.setStrategyLogicAuthAndNewStrategies.selector;
   bytes4 public constant INIT_ROLES_SELECTOR = LlamaGovernanceScript.initRoles.selector;
   bytes4 public constant SET_ROLE_HOLDERS_SELECTOR = LlamaGovernanceScript.setRoleHolders.selector;
   bytes4 public constant SET_ROLE_PERMISSIONS_SELECTOR = LlamaGovernanceScript.setRolePermissions.selector;
   bytes4 public constant REVOKE_POLICIES_SELECTOR = LlamaGovernanceScript.revokePolicies.selector;
   bytes4 public constant UPDATE_ROLE_DESCRIPTIONS_SELECTOR = LlamaGovernanceScript.updateRoleDescriptions.selector;
-  bytes4 public constant SET_STRATEGY_LOGIC_AUTHORIZATIONS_SELECTOR =
-    LlamaGovernanceScript.setStrategyLogicAuthorizations.selector;
-  bytes4 public constant SET_STRATEGY_AUTHORIZATIONS_SELECTOR = LlamaGovernanceScript.setStrategyAuthorizations.selector;
-  bytes4 public constant SET_ACCOUNT_LOGIC_AUTHORIZATIONS_SELECTOR =
-    LlamaGovernanceScript.setAccountLogicAuthorizations.selector;
-  bytes4 public constant SET_STRATEGY_LOGIC_AUTH_AND_NEW_STRATEGIES_SELECTOR =
-    LlamaGovernanceScript.setStrategyLogicAuthAndNewStrategies.selector;
-  bytes4 SET_SCRIPT_AUTH_AND_SET_PERMISSIONS_SELECTOR = LlamaGovernanceScript.setScriptAuthAndSetPermissions.selector;
-  bytes4 CREATE_ACCOUNT_AND_SET_ROLE_PERMISSIONS_SELECTOR =
-    LlamaGovernanceScript.createAccountAndSetRolePermissions.selector;
 
-  PermissionData public executeActionPermission;
   PermissionData public aggregatePermission;
-  PermissionData public initializeRolesAndSetRoleHoldersPermission;
-  PermissionData public initializeRolesAndSetRolePermissionsPermission;
-  PermissionData public initializeRolesAndSetRoleHoldersAndSetRolePermissionsPermission;
-  PermissionData public createNewStrategiesAndSetRoleHoldersPermission;
-  PermissionData public createNewStrategiesAndInitializeRolesAndSetRoleHoldersPermission;
-  PermissionData public createNewStrategiesAndSetRolePermissionsPermission;
-  PermissionData public createNewStrategiesAndNewRolesAndSetRoleHoldersAndSetRolePermissionsPermission;
-  PermissionData public revokePoliciesAndUpdateRoleDescriptionsPermission;
-  PermissionData public revokePoliciesAndSetRoleDescsAndHolders;
-  PermissionData public initializeRolesPermission;
+  PermissionData public initRoleAndHoldersAndPermissionsPermission;
+  PermissionData public createStrategyAndSetRolePermissionsPermission;
+  PermissionData public updateRoleDescriptionAndRoleHoldersPermission;
+  PermissionData public createAccountAndSetRolePermissionsPermission;
+  PermissionData public setScriptAuthAndSetPermissionsPermission;
+  PermissionData public setStrategyLogicAuthorizationsPermission;
+  PermissionData public setAccountLogicAuthorizationsPermission;
+  PermissionData public setStrategyAuthorizationsPermission;
+  PermissionData public setStrategyLogicAuthAndNewStrategiesPermission;
+  PermissionData public initRolesPermission;
   PermissionData public setRoleHoldersPermission;
   PermissionData public setRolePermissionsPermission;
   PermissionData public revokePoliciesPermission;
-  PermissionData public updateRoleDescriptionPerimssion;
-  PermissionData public setStrategyLogicAuthorizationsPermission;
-  PermissionData public setStrategyAuthorizationsPermission;
-  PermissionData public setAccountLogicAuthorizationsPermission;
-  PermissionData public setStrategyLogicAuthAndNewStrategiesPermission;
-  PermissionData public setScriptAuthAndSetPermissionsPermission;
-  PermissionData public createAccountAndSetRolePermissionsPermission;
+  PermissionData public updateRoleDescriptionsPermission;
 
   function setUp() public virtual override {
     LlamaTestSetup.setUp();
@@ -104,72 +86,47 @@ contract LlamaGovernanceScriptTest is LlamaTestSetup {
 
     mpCore.setScriptAuthorization(address(govScript), true);
 
-    executeActionPermission = PermissionData(address(govScript), EXECUTE_ACTION_SELECTOR, mpStrategy2);
     aggregatePermission = PermissionData(address(govScript), AGGREGATE_SELECTOR, mpStrategy2);
-    initializeRolesAndSetRoleHoldersPermission =
-      PermissionData(address(govScript), INIT_ROLES_AND_SET_ROLE_HOLDERS_SELECTOR, mpStrategy2);
-    initializeRolesAndSetRolePermissionsPermission =
-      PermissionData(address(govScript), INITIALIZE_ROLES_AND_SET_ROLE_PERMISSIONS_SELECTOR, mpStrategy2);
-    initializeRolesAndSetRoleHoldersAndSetRolePermissionsPermission =
-      PermissionData(address(govScript), INIT_ROLES_AND_HOLDERS_AND_PERMISSIONS_SELECTOR, mpStrategy2);
-    createNewStrategiesAndSetRoleHoldersPermission =
-      PermissionData(address(govScript), CREATE_NEW_STRATEGIES_AND_SET_ROLE_HOLDERS_SELECTOR, mpStrategy2);
-    createNewStrategiesAndInitializeRolesAndSetRoleHoldersPermission =
-      PermissionData(address(govScript), CREATE_STRATEGIES_AND_INIT_ROLES_AND_HOLDERS_SELECTOR, mpStrategy2);
-    createNewStrategiesAndSetRolePermissionsPermission =
-      PermissionData(address(govScript), CREATE_NEW_STRATEGIES_AND_SET_ROLE_PERMISSIONS_SELECTOR, mpStrategy2);
-    createNewStrategiesAndNewRolesAndSetRoleHoldersAndSetRolePermissionsPermission =
-      PermissionData(address(govScript), CREATE_STRATEGIES_WITH_ROLES_AND_PERMISSIONS_SELECTOR, mpStrategy2);
-    revokePoliciesAndUpdateRoleDescriptionsPermission =
-      PermissionData(address(govScript), REVOKE_POLICIES_AND_UPDATE_ROLE_DESCRIPTIONS_SELECTOR, mpStrategy2);
-    revokePoliciesAndSetRoleDescsAndHolders =
-      PermissionData(address(govScript), REVOKE_POLICIES_AND_SET_ROLE_DESCS_AND_HOLDERS_SELECTOR, mpStrategy2);
-    initializeRolesPermission = PermissionData(address(govScript), INIT_ROLES_SELECTOR, mpStrategy2);
+    initRoleAndHoldersAndPermissionsPermission =
+      PermissionData(address(govScript), INIT_ROLE_AND_HOLDERS_AND_PERMISSIONS_SELECTOR, mpStrategy2);
+    createStrategyAndSetRolePermissionsPermission =
+      PermissionData(address(govScript), CREATE_STRATEGY_AND_SET_ROLE_PERMISSIONS_SELECTOR, mpStrategy2);
+    updateRoleDescriptionAndRoleHoldersPermission =
+      PermissionData(address(govScript), UPDATE_ROLE_DESCRIPTION_AND_ROLE_HOLDERS_SELECTOR, mpStrategy2);
+    createAccountAndSetRolePermissionsPermission =
+      PermissionData(address(govScript), CREATE_ACCOUNT_AND_SET_ROLE_PERMISSIONS_SELECTOR, mpStrategy2);
+    setScriptAuthAndSetPermissionsPermission =
+      PermissionData(address(govScript), SET_SCRIPT_AUTH_AND_SET_PERMISSIONS_SELECTOR, mpStrategy2);
+    setStrategyLogicAuthorizationsPermission =
+      PermissionData(address(govScript), SET_STRATEGY_LOGIC_AUTHORIZATIONS_SELECTOR, mpStrategy2);
+    setAccountLogicAuthorizationsPermission =
+      PermissionData(address(govScript), SET_ACCOUNT_LOGIC_AUTHORIZATIONS_SELECTOR, mpStrategy2);
+    setStrategyAuthorizationsPermission =
+      PermissionData(address(govScript), SET_STRATEGY_AUTHORIZATIONS_SELECTOR, mpStrategy2);
+    setStrategyLogicAuthAndNewStrategiesPermission =
+      PermissionData(address(govScript), SET_STRATEGY_LOGIC_AUTH_AND_NEW_STRATEGIES_SELECTOR, mpStrategy2);
+    initRolesPermission = PermissionData(address(govScript), INIT_ROLES_SELECTOR, mpStrategy2);
     setRoleHoldersPermission = PermissionData(address(govScript), SET_ROLE_HOLDERS_SELECTOR, mpStrategy2);
     setRolePermissionsPermission = PermissionData(address(govScript), SET_ROLE_PERMISSIONS_SELECTOR, mpStrategy2);
     revokePoliciesPermission = PermissionData(address(govScript), REVOKE_POLICIES_SELECTOR, mpStrategy2);
-    updateRoleDescriptionPerimssion = PermissionData(address(govScript), UPDATE_ROLE_DESCRIPTIONS_SELECTOR, mpStrategy2);
-    setStrategyLogicAuthorizationsPermission =
-      PermissionData(address(govScript), SET_STRATEGY_LOGIC_AUTHORIZATIONS_SELECTOR, mpStrategy2);
-    setStrategyAuthorizationsPermission =
-      PermissionData(address(govScript), SET_STRATEGY_AUTHORIZATIONS_SELECTOR, mpStrategy2);
-    setAccountLogicAuthorizationsPermission =
-      PermissionData(address(govScript), SET_ACCOUNT_LOGIC_AUTHORIZATIONS_SELECTOR, mpStrategy2);
-    setStrategyLogicAuthAndNewStrategiesPermission =
-      PermissionData(address(govScript), SET_STRATEGY_LOGIC_AUTH_AND_NEW_STRATEGIES_SELECTOR, mpStrategy2);
-    setScriptAuthAndSetPermissionsPermission =
-      PermissionData(address(govScript), SET_SCRIPT_AUTH_AND_SET_PERMISSIONS_SELECTOR, mpStrategy2);
-    createAccountAndSetRolePermissionsPermission =
-      PermissionData(address(govScript), CREATE_ACCOUNT_AND_SET_ROLE_PERMISSIONS_SELECTOR, mpStrategy2);
+    updateRoleDescriptionsPermission =
+      PermissionData(address(govScript), UPDATE_ROLE_DESCRIPTIONS_SELECTOR, mpStrategy2);
 
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), executeActionPermission, true);
     mpPolicy.setRolePermission(uint8(Roles.ActionCreator), aggregatePermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), initializeRolesAndSetRoleHoldersPermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), initializeRolesAndSetRolePermissionsPermission, true);
-    mpPolicy.setRolePermission(
-      uint8(Roles.ActionCreator), initializeRolesAndSetRoleHoldersAndSetRolePermissionsPermission, true
-    );
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), createNewStrategiesAndSetRoleHoldersPermission, true);
-    mpPolicy.setRolePermission(
-      uint8(Roles.ActionCreator), createNewStrategiesAndInitializeRolesAndSetRoleHoldersPermission, true
-    );
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), createNewStrategiesAndSetRolePermissionsPermission, true);
-    mpPolicy.setRolePermission(
-      uint8(Roles.ActionCreator), createNewStrategiesAndNewRolesAndSetRoleHoldersAndSetRolePermissionsPermission, true
-    );
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), revokePoliciesAndUpdateRoleDescriptionsPermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), revokePoliciesAndSetRoleDescsAndHolders, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), initializeRolesPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), initRoleAndHoldersAndPermissionsPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), createStrategyAndSetRolePermissionsPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), updateRoleDescriptionAndRoleHoldersPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), createAccountAndSetRolePermissionsPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setScriptAuthAndSetPermissionsPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setStrategyLogicAuthorizationsPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setAccountLogicAuthorizationsPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setStrategyAuthorizationsPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setStrategyLogicAuthAndNewStrategiesPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), initRolesPermission, true);
     mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setRoleHoldersPermission, true);
     mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setRolePermissionsPermission, true);
     mpPolicy.setRolePermission(uint8(Roles.ActionCreator), revokePoliciesPermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), updateRoleDescriptionPerimssion, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setStrategyLogicAuthorizationsPermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setStrategyAuthorizationsPermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setAccountLogicAuthorizationsPermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setStrategyLogicAuthAndNewStrategiesPermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), setScriptAuthAndSetPermissionsPermission, true);
-    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), createAccountAndSetRolePermissionsPermission, true);
+    mpPolicy.setRolePermission(uint8(Roles.ActionCreator), updateRoleDescriptionsPermission, true);
 
     vm.stopPrank();
   }
@@ -325,89 +282,89 @@ contract LlamaGovernanceScriptTest is LlamaTestSetup {
   }
 }
 
-// contract Aggregate is LlamaGovernanceScriptTest {
-//   address[] public targets;
-//   bytes[] public calls;
+contract Aggregate is LlamaGovernanceScriptTest {
+  address[] public targets;
+  bytes[] public calls;
 
-//   function test_aggregate(RoleDescription[] memory descriptions) public {
-//     _assumeInitializeRoles(descriptions);
-//     for (uint256 i = 0; i < descriptions.length; i++) {
-//       targets.push(address(mpPolicy));
-//       calls.push(abi.encodeWithSelector(LlamaPolicy.initializeRole.selector, descriptions[i]));
+  function test_aggregate(RoleDescription[] memory descriptions) public {
+    _assumeInitializeRoles(descriptions);
+    for (uint256 i = 0; i < descriptions.length; i++) {
+      targets.push(address(mpPolicy));
+      calls.push(abi.encodeWithSelector(LlamaPolicy.initializeRole.selector, descriptions[i]));
 
-//       targets.push(address(mpPolicy));
-//       calls.push(
-//         abi.encodeWithSelector(
-//           LlamaPolicy.setRoleHolder.selector, uint8(i + 9), address(uint160(i + 101)), 1, type(uint64).max
-//         )
-//       );
-//     }
+      targets.push(address(mpPolicy));
+      calls.push(
+        abi.encodeWithSelector(
+          LlamaPolicy.setRoleHolder.selector, uint8(i + 9), address(uint160(i + 101)), 1, type(uint64).max
+        )
+      );
+    }
 
-//     LlamaAccount.Config[] memory newAccounts = new LlamaAccount.Config[](1);
-//     newAccounts[0] = LlamaAccount.Config({name: "new treasury"});
+    LlamaAccount.Config[] memory newAccounts = new LlamaAccount.Config[](1);
+    newAccounts[0] = LlamaAccount.Config({name: "new treasury"});
 
-//     ILlamaAccount[] memory accountAddresses = new ILlamaAccount[](1);
-//     for (uint256 i; i < newAccounts.length; i++) {
-//       accountAddresses[i] = lens.computeLlamaAccountAddress(
-//         address(accountLogic), DeployUtils.encodeAccount(newAccounts[i]), address(mpCore)
-//       );
-//     }
+    ILlamaAccount[] memory accountAddresses = new ILlamaAccount[](1);
+    for (uint256 i; i < newAccounts.length; i++) {
+      accountAddresses[i] = lens.computeLlamaAccountAddress(
+        address(accountLogic), DeployUtils.encodeAccount(newAccounts[i]), address(mpCore)
+      );
+    }
 
-//     targets.push(address(mpCore));
-//     calls.push(abi.encodeWithSelector(0x90010bb0, accountLogic, DeployUtils.encodeAccountConfigs(newAccounts)));
+    targets.push(address(mpCore));
+    calls.push(abi.encodeWithSelector(0x90010bb0, accountLogic, DeployUtils.encodeAccountConfigs(newAccounts)));
 
-//     bytes memory data = abi.encodeWithSelector(AGGREGATE_SELECTOR, targets, calls);
+    bytes memory data = abi.encodeWithSelector(AGGREGATE_SELECTOR, targets, calls);
 
-//     (ActionInfo memory actionInfo) = _createAction(data);
+    (ActionInfo memory actionInfo) = _createAction(data);
 
-//     _expectInitializeRolesEvents(descriptions);
-//     vm.expectEmit();
-//     emit AccountCreated(accountAddresses[0], accountLogic, DeployUtils.encodeAccount(newAccounts[0]));
-//     mpCore.executeAction(actionInfo);
-//   }
+    _expectInitializeRolesEvents(descriptions);
+    vm.expectEmit();
+    emit AccountCreated(accountAddresses[0], accountLogic, DeployUtils.encodeAccount(newAccounts[0]));
+    mpCore.executeAction(actionInfo);
+  }
 
-//   function test_RevertsIf_CallReverted(RoleDescription description) public {
-//     targets.push(address(0));
-//     calls.push(abi.encodeWithSelector(LlamaPolicy.initializeRole.selector, description));
+  function test_RevertsIf_CallReverted(RoleDescription description) public {
+    targets.push(address(0));
+    calls.push(abi.encodeWithSelector(LlamaPolicy.initializeRole.selector, description));
 
-//     bytes memory data = abi.encodeWithSelector(AGGREGATE_SELECTOR, targets, calls);
+    bytes memory data = abi.encodeWithSelector(AGGREGATE_SELECTOR, targets, calls);
 
-//     (ActionInfo memory actionInfo) = _createAction(data);
+    (ActionInfo memory actionInfo) = _createAction(data);
 
-//     vm.expectRevert();
-//     // CallReverted error cannot be reached because we get a "FailedActionExecution" error first.
-//     mpCore.executeAction(actionInfo);
-//   }
+    vm.expectRevert();
+    // CallReverted error cannot be reached because we get a "FailedActionExecution" error first.
+    mpCore.executeAction(actionInfo);
+  }
 
-//   function test_RevertsIf_UnauthorizedTarget(address target) public {
-//     vm.assume(target != address(mpPolicy) && target != address(mpCore));
-//     targets.push(address(target));
-//     calls.push(abi.encodeWithSelector(LlamaPolicy.initializeRole.selector, "test"));
+  function test_RevertsIf_UnauthorizedTarget(address target) public {
+    vm.assume(target != address(mpPolicy) && target != address(mpCore));
+    targets.push(address(target));
+    calls.push(abi.encodeWithSelector(LlamaPolicy.initializeRole.selector, "test"));
 
-//     bytes memory data = abi.encodeWithSelector(AGGREGATE_SELECTOR, targets, calls);
-//     (ActionInfo memory actionInfo) = _createAction(data);
+    bytes memory data = abi.encodeWithSelector(AGGREGATE_SELECTOR, targets, calls);
+    (ActionInfo memory actionInfo) = _createAction(data);
 
-//     vm.expectRevert();
-//     // UnauthorizedTarget error cannot be reached because we get a "FailedActionExecution" error first.
-//     mpCore.executeAction(actionInfo);
-//   }
+    vm.expectRevert();
+    // UnauthorizedTarget error cannot be reached because we get a "FailedActionExecution" error first.
+    mpCore.executeAction(actionInfo);
+  }
 
-//   function test_RevertsIf_MismatchedArrayLength(address[] calldata _targets, uint8 length) public {
-//     vm.assume(targets.length != length);
-//     bytes[] memory _calls = new bytes[](length);
-//     for (uint256 i = 0; i < length; i++) {
-//       _calls[i] = abi.encodeWithSelector(LlamaPolicy.initializeRole.selector, "test");
-//     }
-//     bytes memory data = abi.encodeWithSelector(AGGREGATE_SELECTOR, _targets, _calls);
-//     (ActionInfo memory actionInfo) = _createAction(data);
+  function test_RevertsIf_MismatchedArrayLength(address[] calldata _targets, uint8 length) public {
+    vm.assume(targets.length != length);
+    bytes[] memory _calls = new bytes[](length);
+    for (uint256 i = 0; i < length; i++) {
+      _calls[i] = abi.encodeWithSelector(LlamaPolicy.initializeRole.selector, "test");
+    }
+    bytes memory data = abi.encodeWithSelector(AGGREGATE_SELECTOR, _targets, _calls);
+    (ActionInfo memory actionInfo) = _createAction(data);
 
-//     vm.expectRevert();
-//     // MismatchedArrayLength error cannot be reached because we get a "FailedActionExecution" error first.
-//     mpCore.executeAction(actionInfo);
-//   }
-// }
+    vm.expectRevert();
+    // MismatchedArrayLength error cannot be reached because we get a "FailedActionExecution" error first.
+    mpCore.executeAction(actionInfo);
+  }
+}
 
-// contract InitializeRolesAndSetRoleHolders is LlamaGovernanceScriptTest {
+// contract InitRoleAndHoldersAndPermissions is LlamaGovernanceScriptTest {
 //   function testFuzz_initializeRolesAndSetRoleHolders(
 //     RoleDescription[] memory descriptions,
 //     RoleHolderData[] memory roleHolders
@@ -423,112 +380,7 @@ contract LlamaGovernanceScriptTest is LlamaTestSetup {
 //   }
 // }
 
-// contract InitializeRolesAndSetRolePermissions is LlamaGovernanceScriptTest {
-//   function test_initializesRolesAndSetRolePermissions(
-//     RoleDescription[] memory descriptions,
-//     RolePermissionData[] memory rolePermissions
-//   ) public {
-//     vm.assume(rolePermissions.length < 50);
-//     _assumeInitializeRoles(descriptions);
-//     _boundRolePermissions(rolePermissions);
-
-//     bytes memory data =
-//       abi.encodeWithSelector(INITIALIZE_ROLES_AND_SET_ROLE_PERMISSIONS_SELECTOR, descriptions, rolePermissions);
-//     (ActionInfo memory actionInfo) = _createAction(data);
-//     _expectInitializeRolesEvents(descriptions);
-//     _expectRolePermissionEvents(rolePermissions);
-//     mpCore.executeAction(actionInfo);
-//   }
-// }
-
-// contract InitializeRolesAndSetRoleHoldersAndSetRolePermissions is LlamaGovernanceScriptTest {
-//   function test_InitializeRolesAndSetRoleHoldersAndSetRolePermissions(
-//     RoleDescription[] memory descriptions,
-//     RolePermissionData[] memory rolePermissions
-//   ) public {
-//     vm.assume(rolePermissions.length < 10);
-//     _assumeInitializeRoles(descriptions);
-//     _boundRolePermissions(rolePermissions);
-
-//     RoleHolderData[] memory roleHolders = new RoleHolderData[](1); // we don't fuzz the roleholders here because the
-//       // test takes too long
-//     roleHolders[0] = RoleHolderData({
-//       policyholder: address(uint160(1)),
-//       role: uint8(Roles.ActionCreator),
-//       expiration: type(uint64).max,
-//       quantity: 1
-//     });
-
-//     bytes memory data = abi.encodeWithSelector(
-//       INIT_ROLES_AND_HOLDERS_AND_PERMISSIONS_SELECTOR, descriptions, roleHolders, rolePermissions
-//     );
-//     (ActionInfo memory actionInfo) = _createAction(data);
-//     _expectInitializeRolesEvents(descriptions);
-//     _expectRoleHolderEvents(roleHolders);
-//     _expectRolePermissionEvents(rolePermissions);
-//     mpCore.executeAction(actionInfo);
-//   }
-// }
-
-// contract CreateNewStrategiesAndSetRoleHolders is LlamaGovernanceScriptTest {
-//   function test_CreateNewStrategiesAndSetRoleHolders(
-//     RoleHolderData[] memory roleHolders,
-//     uint256 salt1,
-//     uint256 salt2,
-//     uint256 salt3,
-//     bool isFixedLengthApprovalPeriod
-//   ) public {
-//     _assumeRoleHolders(roleHolders);
-//     _assumeStrategies(salt1, salt2, salt3);
-
-//     (LlamaRelativeStrategyBase.Config[] memory newStrategies, LlamaGovernanceScript.CreateStrategy memory strategies)
-// =
-//       _createStrategies(salt1, salt2, salt3, isFixedLengthApprovalPeriod);
-
-//     bytes memory data =
-//       abi.encodeWithSelector(CREATE_NEW_STRATEGIES_AND_SET_ROLE_HOLDERS_SELECTOR, strategies, roleHolders);
-//     (ActionInfo memory actionInfo) = _createAction(data);
-
-//     _expectCreateStrategiesEvents(newStrategies);
-//     _expectRoleHolderEvents(roleHolders);
-
-//     vm.startPrank(address(mpExecutor));
-//     mpCore.executeAction(actionInfo);
-//   }
-// }
-
-// contract CreateNewStrategiesAndInitializeRolesAndSetRoleHolders is LlamaGovernanceScriptTest {
-//   function test_CreateNewStrategiesAndSetRoleHolders(
-//     RoleDescription[] memory descriptions,
-//     RoleHolderData[] memory roleHolders,
-//     uint256 salt1,
-//     uint256 salt2,
-//     uint256 salt3,
-//     bool isFixedLengthApprovalPeriod
-//   ) public {
-//     _assumeInitializeRoles(descriptions);
-//     _assumeRoleHolders(roleHolders);
-//     _assumeStrategies(salt1, salt2, salt3);
-
-//     (LlamaRelativeStrategyBase.Config[] memory newStrategies, LlamaGovernanceScript.CreateStrategy memory strategies)
-// =
-//       _createStrategies(salt1, salt2, salt3, isFixedLengthApprovalPeriod);
-
-//     bytes memory data = abi.encodeWithSelector(
-//       CREATE_STRATEGIES_AND_INIT_ROLES_AND_HOLDERS_SELECTOR, strategies, descriptions, roleHolders
-//     );
-//     (ActionInfo memory actionInfo) = _createAction(data);
-
-//     _expectCreateStrategiesEvents(newStrategies);
-//     _expectInitializeRolesEvents(descriptions);
-//     _expectRoleHolderEvents(roleHolders);
-
-//     vm.startPrank(address(mpExecutor));
-//     mpCore.executeAction(actionInfo);
-//   }
-// }
-
-// contract CreateNewStrategiesAndSetRolePermissions is LlamaGovernanceScriptTest {
+// contract CreateStrategyAndSetRolePermissions is LlamaGovernanceScriptTest {
 //   function test_CreateNewStrategiesAndSetRolePermissions(
 //     RolePermissionData[] memory rolePermissions,
 //     uint256 salt1,
@@ -555,96 +407,221 @@ contract LlamaGovernanceScriptTest is LlamaTestSetup {
 //   }
 // }
 
-// contract CreateNewStrategiesAndInitializeRolesAndSetRoleHoldersAndSetRolePermissions is LlamaGovernanceScriptTest {
-//   function test_CreateNewStrategiesAndInitializeRolesAndSetRoleHoldersAndSetRolePermissions(
-//     RoleDescription[] memory descriptions,
-//     RolePermissionData[] memory rolePermissions,
-//     uint256 salt1,
-//     uint256 salt2,
-//     uint256 salt3,
-//     bool isFixedLengthApprovalPeriod
-//   ) public {
-//     _assumeInitializeRoles(descriptions);
-//     _boundRolePermissions(rolePermissions);
-//     _assumeStrategies(salt1, salt2, salt3);
+// contract UpdateRoleDescriptionAndRoleHolders is LlamaGovernanceScriptTest {}
 
-//     (LlamaRelativeStrategyBase.Config[] memory newStrategies, LlamaGovernanceScript.CreateStrategy memory strategies)
-// =
-//       _createStrategies(salt1, salt2, salt3, isFixedLengthApprovalPeriod);
+// contract CreateAccountAndSetRolePermissions is LlamaGovernanceScriptTest {
+//   function test_CreateAccountAndSetRolePermissions() public {
+//     bytes memory config = abi.encode(LlamaAccount.Config({name: "mockAccountERC20"}));
+//     LlamaGovernanceScript.CreateAccounts memory account = LlamaGovernanceScript.CreateAccounts(accountLogic, config);
 
-//     RoleHolderData[] memory roleHolders = new RoleHolderData[](1); // we don't fuzz the roleholders here because the
-//       // test takes too long
-//     roleHolders[0] = RoleHolderData({
-//       policyholder: address(uint160(1)),
-//       role: uint8(Roles.ActionCreator),
-//       expiration: type(uint64).max,
-//       quantity: 1
-//     });
+//     ILlamaAccount accountAddress = lens.computeLlamaAccountAddress(address(accountLogic), config, address(mpCore));
 
-//     bytes memory data = abi.encodeWithSelector(
-//       CREATE_STRATEGIES_WITH_ROLES_AND_PERMISSIONS_SELECTOR, strategies, descriptions, roleHolders, rolePermissions
-//     );
-//     (ActionInfo memory actionInfo) = _createAction(data);
+//     PermissionData memory permissionData1 =
+//       PermissionData(address(accountAddress), LlamaAccount.batchTransferNativeToken.selector, mpStrategy2);
+//     PermissionData memory permissionData2 =
+//       PermissionData(address(accountAddress), LlamaAccount.batchTransferERC20.selector, mpStrategy2);
+//     PermissionData memory permissionData3 =
+//       PermissionData(address(accountAddress), LlamaAccount.batchApproveERC20.selector, mpStrategy2);
+//     PermissionData memory permissionData4 =
+//       PermissionData(address(accountAddress), LlamaAccount.batchTransferERC721.selector, mpStrategy2);
+//     PermissionData memory permissionData5 =
+//       PermissionData(address(accountAddress), LlamaAccount.batchApproveERC721.selector, mpStrategy2);
+//     PermissionData memory permissionData6 =
+//       PermissionData(address(accountAddress), LlamaAccount.batchApproveOperatorERC721.selector, mpStrategy2);
 
-//     _expectCreateStrategiesEvents(newStrategies);
-//     _expectInitializeRolesEvents(descriptions);
-//     _expectRoleHolderEvents(roleHolders);
-//     _expectRolePermissionEvents(rolePermissions);
-
-//     mpCore.executeAction(actionInfo);
-//   }
-// }
-
-// contract RevokePoliciesAndUpdateRoleDescriptions is LlamaGovernanceScriptTest {
-//   function test_RevokePoliciesAndUpdateRoleDescriptions(
-//     LlamaGovernanceScript.UpdateRoleDescription[] memory descriptions
-//   ) public {
-//     revokePolicies.push(disapproverDave);
-//     _assumeUpdateRoleDescriptions(descriptions);
+//     RolePermissionData[] memory _permissions = new RolePermissionData[](6);
+//     _permissions[0] = RolePermissionData(uint8(Roles.ActionCreator), permissionData1, true);
+//     _permissions[1] = RolePermissionData(uint8(Roles.ActionCreator), permissionData2, true);
+//     _permissions[2] = RolePermissionData(uint8(Roles.ActionCreator), permissionData3, true);
+//     _permissions[3] = RolePermissionData(uint8(Roles.ActionCreator), permissionData4, true);
+//     _permissions[4] = RolePermissionData(uint8(Roles.ActionCreator), permissionData5, true);
+//     _permissions[5] = RolePermissionData(uint8(Roles.ActionCreator), permissionData6, true);
 
 //     bytes memory data =
-//       abi.encodeWithSelector(REVOKE_POLICIES_AND_UPDATE_ROLE_DESCRIPTIONS_SELECTOR, revokePolicies, descriptions);
+//       abi.encodeWithSelector(LlamaGovernanceScript.createAccountAndSetRolePermissions.selector, account,
+// _permissions);
+
 //     (ActionInfo memory actionInfo) = _createAction(data);
 
 //     vm.expectEmit();
-//     emit RoleAssigned(address(disapproverDave), uint8(Roles.Disapprover), 0, 0);
-//     _expectUpdateRoleDescriptionsEvents(descriptions);
+//     emit AccountCreated(accountAddress, accountLogic, config);
+
+//     vm.expectEmit();
+//     emit RolePermissionAssigned(
+//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData1), permissionData1, true
+//     );
+
+//     vm.expectEmit();
+//     emit RolePermissionAssigned(
+//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData2), permissionData2, true
+//     );
+
+//     vm.expectEmit();
+//     emit RolePermissionAssigned(
+//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData3), permissionData3, true
+//     );
+
+//     vm.expectEmit();
+//     emit RolePermissionAssigned(
+//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData4), permissionData4, true
+//     );
+
+//     vm.expectEmit();
+//     emit RolePermissionAssigned(
+//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData5), permissionData5, true
+//     );
+
+//     vm.expectEmit();
+//     emit RolePermissionAssigned(
+//       uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData6), permissionData6, true
+//     );
+
+//     mpCore.executeAction(actionInfo);
+//   }
+
+//   function test_RevertsIf_TargetIsNotAccount(address notAccount) public {
+//     bytes memory config = abi.encode(LlamaAccount.Config({name: "mockAccountERC20"}));
+//     LlamaGovernanceScript.CreateAccounts memory account = LlamaGovernanceScript.CreateAccounts(accountLogic, config);
+
+//     ILlamaAccount accountAddress = lens.computeLlamaAccountAddress(address(accountLogic), config, address(mpCore));
+
+//     vm.assume(notAccount != address(accountAddress));
+
+//     PermissionData memory permissionData =
+//       PermissionData(notAccount, LlamaAccount.batchTransferNativeToken.selector, mpStrategy2);
+
+//     RolePermissionData[] memory _permissions = new RolePermissionData[](1);
+//     _permissions[0] = RolePermissionData(uint8(Roles.ActionCreator), permissionData, true);
+
+//     bytes memory data =
+//       abi.encodeWithSelector(LlamaGovernanceScript.createAccountAndSetRolePermissions.selector, account,
+// _permissions);
+
+//     (ActionInfo memory actionInfo) = _createAction(data);
+
+//     vm.expectRevert(); // reverts with FailedActionExecution and does not reach the TargetIsNotAccount error
 
 //     mpCore.executeAction(actionInfo);
 //   }
 // }
 
-// contract RevokePoliciesAndSetRoleDescsAndHolders is LlamaGovernanceScriptTest {
-//   function test_RevokePoliciesAndSetRoleDescsAndHolders(
-//     LlamaGovernanceScript.UpdateRoleDescription[] memory descriptions
-//   ) public {
-//     revokePolicies.push(disapproverDave);
-//     _assumeUpdateRoleDescriptions(descriptions);
-
-//     RoleHolderData[] memory roleHolders = new RoleHolderData[](1); // we don't fuzz the roleholders here because the
-//     // test takes too long
-//     roleHolders[0] = RoleHolderData({
-//       policyholder: address(uint160(1)),
-//       role: uint8(Roles.ActionCreator),
-//       expiration: type(uint64).max,
-//       quantity: 1
-//     });
+// contract SetScriptAuthAndSetPermissions is LlamaGovernanceScriptTest {
+//   function test_SetScriptAuthAndSetPermissions(address script, bool authorized, bytes4[] calldata selectors) public {
+//     ILlamaStrategy[] memory strategies = new ILlamaStrategy[](selectors.length);
 
 //     bytes memory data = abi.encodeWithSelector(
-//       REVOKE_POLICIES_AND_SET_ROLE_DESCS_AND_HOLDERS_SELECTOR, revokePolicies, descriptions, roleHolders
+//       LlamaGovernanceScript.setScriptAuthAndSetPermissions.selector,
+//       script,
+//       authorized,
+//       uint8(Roles.ActionCreator),
+//       selectors,
+//       strategies
 //     );
 //     (ActionInfo memory actionInfo) = _createAction(data);
 
 //     vm.expectEmit();
-//     emit RoleAssigned(address(disapproverDave), uint8(Roles.Disapprover), 0, 0);
-//     _expectUpdateRoleDescriptionsEvents(descriptions);
-//     _expectRoleHolderEvents(roleHolders);
-
+//     emit ScriptAuthorizationSet(script, authorized);
+//     for (uint256 i = 0; i < selectors.length; i++) {
+//       PermissionData memory permissionData = PermissionData(script, selectors[i], strategies[i]);
+//       bytes32 permissionId = lens.computePermissionId(permissionData);
+//       vm.expectEmit();
+//       emit RolePermissionAssigned(uint8(Roles.ActionCreator), permissionId, permissionData, authorized);
+//     }
 //     mpCore.executeAction(actionInfo);
 //   }
 // }
 
-contract InitializeRoles is LlamaGovernanceScriptTest {
+contract SetStrategyLogicAuthorizations is LlamaGovernanceScriptTest {
+  function test_setStrategyLogicAuthorizations(bool authorized) public {
+    ILlamaStrategy[] memory strategies = new ILlamaStrategy[](3);
+    strategies[0] = relativeHolderQuorumLogic;
+    strategies[1] = absolutePeerReviewLogic;
+    strategies[2] = absoluteQuorumLogic;
+
+    bytes memory data =
+      abi.encodeWithSelector(LlamaGovernanceScript.setStrategyLogicAuthorizations.selector, strategies, authorized);
+    (ActionInfo memory actionInfo) = _createAction(data);
+
+    vm.expectEmit();
+    emit StrategyLogicAuthorizationSet(relativeHolderQuorumLogic, authorized);
+    vm.expectEmit();
+    emit StrategyLogicAuthorizationSet(absolutePeerReviewLogic, authorized);
+    vm.expectEmit();
+    emit StrategyLogicAuthorizationSet(absoluteQuorumLogic, authorized);
+
+    mpCore.executeAction(actionInfo);
+  }
+}
+
+contract SetAccountLogicAuthorizations is LlamaGovernanceScriptTest {
+  function test_SetAccountLogicAuthorizations(ILlamaAccount[] calldata accountLogics, bool authorized) public {
+    vm.assume(accountLogics.length < 5);
+
+    bytes memory data =
+      abi.encodeWithSelector(LlamaGovernanceScript.setAccountLogicAuthorizations.selector, accountLogics, authorized);
+    (ActionInfo memory actionInfo) = _createAction(data);
+
+    for (uint256 i = 0; i < accountLogics.length; i++) {
+      vm.expectEmit();
+      emit AccountLogicAuthorizationSet(accountLogics[i], authorized);
+    }
+
+    mpCore.executeAction(actionInfo);
+  }
+}
+
+contract SetStrategyAuthorizations is LlamaGovernanceScriptTest {
+  function test_setStrategyAuthorizations(bool authorized) public {
+    ILlamaStrategy[] memory strategies = new ILlamaStrategy[](1);
+    strategies[0] = mpStrategy1;
+
+    bytes memory data =
+      abi.encodeWithSelector(LlamaGovernanceScript.setStrategyAuthorizations.selector, strategies, authorized);
+    (ActionInfo memory actionInfo) = _createAction(data);
+
+    vm.expectEmit();
+    emit StrategyAuthorizationSet(mpStrategy1, authorized);
+
+    mpCore.executeAction(actionInfo);
+  }
+}
+
+contract SetStrategyLogicAuthAndNewStrategies is LlamaGovernanceScriptTest {
+  function test_SetStrategyLogicAuthorizationAndCreateStrategies() public {
+    LlamaRelativeStrategyBase.Config[] memory newStrategies = new LlamaRelativeStrategyBase.Config[](1);
+    newStrategies[0] = LlamaRelativeStrategyBase.Config({
+      approvalPeriod: 0,
+      queuingPeriod: 0,
+      expirationPeriod: 2 days,
+      isFixedLengthApprovalPeriod: false,
+      minApprovalPct: 0,
+      minDisapprovalPct: 10_001,
+      approvalRole: uint8(Roles.Approver),
+      disapprovalRole: uint8(Roles.Disapprover),
+      forceApprovalRoles: new uint8[](0),
+      forceDisapprovalRoles: new uint8[](0)
+    });
+    ILlamaStrategy instantExecutionStrategy = lens.computeLlamaStrategyAddress(
+      address(relativeQuantityQuorumLogic), DeployUtils.encodeStrategy(newStrategies[0]), address(mpCore)
+    );
+    bytes memory data = abi.encodeWithSelector(
+      LlamaGovernanceScript.setStrategyLogicAuthAndNewStrategies.selector,
+      relativeQuantityQuorumLogic,
+      DeployUtils.encodeStrategyConfigs(newStrategies)
+    );
+    (ActionInfo memory actionInfo) = _createAction(data);
+
+    vm.expectEmit();
+    emit StrategyLogicAuthorizationSet(relativeQuantityQuorumLogic, true);
+    vm.expectEmit();
+    emit StrategyCreated(
+      instantExecutionStrategy, relativeQuantityQuorumLogic, DeployUtils.encodeStrategy(newStrategies[0])
+    );
+    mpCore.executeAction(actionInfo);
+  }
+}
+
+contract InitRoles is LlamaGovernanceScriptTest {
   function testFuzz_initializeRoles(RoleDescription[] memory descriptions) public {
     _assumeInitializeRoles(descriptions);
     bytes memory data = abi.encodeWithSelector(INIT_ROLES_SELECTOR, descriptions);
@@ -694,216 +671,6 @@ contract UpdateRoleDescriptions is LlamaGovernanceScriptTest {
     (ActionInfo memory actionInfo) = _createAction(data);
 
     _expectUpdateRoleDescriptionsEvents(roleDescriptions);
-    mpCore.executeAction(actionInfo);
-  }
-}
-
-contract SetStrategyLogicAuthorizations is LlamaGovernanceScriptTest {
-  function test_setStrategyLogicAuthorizations(bool authorized) public {
-    ILlamaStrategy[] memory strategies = new ILlamaStrategy[](3);
-    strategies[0] = relativeHolderQuorumLogic;
-    strategies[1] = absolutePeerReviewLogic;
-    strategies[2] = absoluteQuorumLogic;
-
-    bytes memory data =
-      abi.encodeWithSelector(LlamaGovernanceScript.setStrategyLogicAuthorizations.selector, strategies, authorized);
-    (ActionInfo memory actionInfo) = _createAction(data);
-
-    vm.expectEmit();
-    emit StrategyLogicAuthorizationSet(relativeHolderQuorumLogic, authorized);
-    vm.expectEmit();
-    emit StrategyLogicAuthorizationSet(absolutePeerReviewLogic, authorized);
-    vm.expectEmit();
-    emit StrategyLogicAuthorizationSet(absoluteQuorumLogic, authorized);
-
-    mpCore.executeAction(actionInfo);
-  }
-}
-
-contract SetStrategyAuthorizations is LlamaGovernanceScriptTest {
-  function test_setStrategyAuthorizations(bool authorized) public {
-    ILlamaStrategy[] memory strategies = new ILlamaStrategy[](1);
-    strategies[0] = mpStrategy1;
-
-    bytes memory data =
-      abi.encodeWithSelector(LlamaGovernanceScript.setStrategyAuthorizations.selector, strategies, authorized);
-    (ActionInfo memory actionInfo) = _createAction(data);
-
-    vm.expectEmit();
-    emit StrategyAuthorizationSet(mpStrategy1, authorized);
-
-    mpCore.executeAction(actionInfo);
-  }
-}
-
-contract SetAccountLogicAuthorizations is LlamaGovernanceScriptTest {
-  function test_SetAccountLogicAuthorizations(ILlamaAccount[] calldata accountLogics, bool authorized) public {
-    vm.assume(accountLogics.length < 5);
-
-    bytes memory data =
-      abi.encodeWithSelector(LlamaGovernanceScript.setAccountLogicAuthorizations.selector, accountLogics, authorized);
-    (ActionInfo memory actionInfo) = _createAction(data);
-
-    for (uint256 i = 0; i < accountLogics.length; i++) {
-      vm.expectEmit();
-      emit AccountLogicAuthorizationSet(accountLogics[i], authorized);
-    }
-
-    mpCore.executeAction(actionInfo);
-  }
-}
-
-contract SetStrategyLogicAuthorizationAndCreateStrategies is LlamaGovernanceScriptTest {
-  function test_SetStrategyLogicAuthorizationAndCreateStrategies() public {
-    LlamaRelativeStrategyBase.Config[] memory newStrategies = new LlamaRelativeStrategyBase.Config[](1);
-    newStrategies[0] = LlamaRelativeStrategyBase.Config({
-      approvalPeriod: 0,
-      queuingPeriod: 0,
-      expirationPeriod: 2 days,
-      isFixedLengthApprovalPeriod: false,
-      minApprovalPct: 0,
-      minDisapprovalPct: 10_001,
-      approvalRole: uint8(Roles.Approver),
-      disapprovalRole: uint8(Roles.Disapprover),
-      forceApprovalRoles: new uint8[](0),
-      forceDisapprovalRoles: new uint8[](0)
-    });
-    ILlamaStrategy instantExecutionStrategy = lens.computeLlamaStrategyAddress(
-      address(relativeQuantityQuorumLogic), DeployUtils.encodeStrategy(newStrategies[0]), address(mpCore)
-    );
-    bytes memory data = abi.encodeWithSelector(
-      LlamaGovernanceScript.setStrategyLogicAuthAndNewStrategies.selector,
-      relativeQuantityQuorumLogic,
-      DeployUtils.encodeStrategyConfigs(newStrategies)
-    );
-    (ActionInfo memory actionInfo) = _createAction(data);
-
-    vm.expectEmit();
-    emit StrategyLogicAuthorizationSet(relativeQuantityQuorumLogic, true);
-    vm.expectEmit();
-    emit StrategyCreated(
-      instantExecutionStrategy, relativeQuantityQuorumLogic, DeployUtils.encodeStrategy(newStrategies[0])
-    );
-    mpCore.executeAction(actionInfo);
-  }
-}
-
-contract SetScriptAuthAndSetPermissions is LlamaGovernanceScriptTest {
-  function test_SetScriptAuthAndSetPermissions(address script, bool authorized, bytes4[] calldata selectors) public {
-    ILlamaStrategy[] memory strategies = new ILlamaStrategy[](selectors.length);
-
-    bytes memory data = abi.encodeWithSelector(
-      LlamaGovernanceScript.setScriptAuthAndSetPermissions.selector,
-      script,
-      authorized,
-      uint8(Roles.ActionCreator),
-      selectors,
-      strategies
-    );
-    (ActionInfo memory actionInfo) = _createAction(data);
-
-    vm.expectEmit();
-    emit ScriptAuthorizationSet(script, authorized);
-    for (uint256 i = 0; i < selectors.length; i++) {
-      PermissionData memory permissionData = PermissionData(script, selectors[i], strategies[i]);
-      bytes32 permissionId = lens.computePermissionId(permissionData);
-      vm.expectEmit();
-      emit RolePermissionAssigned(uint8(Roles.ActionCreator), permissionId, permissionData, authorized);
-    }
-    mpCore.executeAction(actionInfo);
-  }
-}
-
-contract CreateAccountAndSetRolePermissions is LlamaGovernanceScriptTest {
-  function test_CreateAccountAndSetRolePermissions() public {
-    bytes memory config = abi.encode(LlamaAccount.Config({name: "mockAccountERC20"}));
-    LlamaGovernanceScript.CreateAccounts memory account = LlamaGovernanceScript.CreateAccounts(accountLogic, config);
-
-    ILlamaAccount accountAddress = lens.computeLlamaAccountAddress(address(accountLogic), config, address(mpCore));
-
-    PermissionData memory permissionData1 =
-      PermissionData(address(accountAddress), LlamaAccount.batchTransferNativeToken.selector, mpStrategy2);
-    PermissionData memory permissionData2 =
-      PermissionData(address(accountAddress), LlamaAccount.batchTransferERC20.selector, mpStrategy2);
-    PermissionData memory permissionData3 =
-      PermissionData(address(accountAddress), LlamaAccount.batchApproveERC20.selector, mpStrategy2);
-    PermissionData memory permissionData4 =
-      PermissionData(address(accountAddress), LlamaAccount.batchTransferERC721.selector, mpStrategy2);
-    PermissionData memory permissionData5 =
-      PermissionData(address(accountAddress), LlamaAccount.batchApproveERC721.selector, mpStrategy2);
-    PermissionData memory permissionData6 =
-      PermissionData(address(accountAddress), LlamaAccount.batchApproveOperatorERC721.selector, mpStrategy2);
-
-    RolePermissionData[] memory _permissions = new RolePermissionData[](6);
-    _permissions[0] = RolePermissionData(uint8(Roles.ActionCreator), permissionData1, true);
-    _permissions[1] = RolePermissionData(uint8(Roles.ActionCreator), permissionData2, true);
-    _permissions[2] = RolePermissionData(uint8(Roles.ActionCreator), permissionData3, true);
-    _permissions[3] = RolePermissionData(uint8(Roles.ActionCreator), permissionData4, true);
-    _permissions[4] = RolePermissionData(uint8(Roles.ActionCreator), permissionData5, true);
-    _permissions[5] = RolePermissionData(uint8(Roles.ActionCreator), permissionData6, true);
-
-    bytes memory data =
-      abi.encodeWithSelector(LlamaGovernanceScript.createAccountAndSetRolePermissions.selector, account, _permissions);
-
-    (ActionInfo memory actionInfo) = _createAction(data);
-
-    vm.expectEmit();
-    emit AccountCreated(accountAddress, accountLogic, config);
-
-    vm.expectEmit();
-    emit RolePermissionAssigned(
-      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData1), permissionData1, true
-    );
-
-    vm.expectEmit();
-    emit RolePermissionAssigned(
-      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData2), permissionData2, true
-    );
-
-    vm.expectEmit();
-    emit RolePermissionAssigned(
-      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData3), permissionData3, true
-    );
-
-    vm.expectEmit();
-    emit RolePermissionAssigned(
-      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData4), permissionData4, true
-    );
-
-    vm.expectEmit();
-    emit RolePermissionAssigned(
-      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData5), permissionData5, true
-    );
-
-    vm.expectEmit();
-    emit RolePermissionAssigned(
-      uint8(Roles.ActionCreator), LlamaUtils.computePermissionId(permissionData6), permissionData6, true
-    );
-
-    mpCore.executeAction(actionInfo);
-  }
-
-  function test_RevertsIf_TargetIsNotAccount(address notAccount) public {
-    bytes memory config = abi.encode(LlamaAccount.Config({name: "mockAccountERC20"}));
-    LlamaGovernanceScript.CreateAccounts memory account = LlamaGovernanceScript.CreateAccounts(accountLogic, config);
-
-    ILlamaAccount accountAddress = lens.computeLlamaAccountAddress(address(accountLogic), config, address(mpCore));
-
-    vm.assume(notAccount != address(accountAddress));
-
-    PermissionData memory permissionData =
-      PermissionData(notAccount, LlamaAccount.batchTransferNativeToken.selector, mpStrategy2);
-
-    RolePermissionData[] memory _permissions = new RolePermissionData[](1);
-    _permissions[0] = RolePermissionData(uint8(Roles.ActionCreator), permissionData, true);
-
-    bytes memory data =
-      abi.encodeWithSelector(LlamaGovernanceScript.createAccountAndSetRolePermissions.selector, account, _permissions);
-
-    (ActionInfo memory actionInfo) = _createAction(data);
-
-    vm.expectRevert(); // reverts with FailedActionExecution and does not reach the TargetIsNotAccount error
-
     mpCore.executeAction(actionInfo);
   }
 }

--- a/test/llama-scripts/LlamaGovernanceScript.t.sol
+++ b/test/llama-scripts/LlamaGovernanceScript.t.sol
@@ -398,7 +398,7 @@ contract InitRoleAndHoldersAndPermissions is LlamaGovernanceScriptTest {
   function testFuzz_initRolesSetRoleHolders(RoleDescription description, RoleHolderData[] memory roleHolders) public {
     uint8 newRole = mpPolicy.numRoles() + 1;
     _assumeRoleHolder(roleHolders, newRole);
-    RolePermissionData[] memory permissionData = new RolePermissionData[](0);
+    PermissionData[] memory permissionData = new PermissionData[](0);
     RoleDescription[] memory descriptions = new RoleDescription[](1);
     descriptions[0] = description;
     bytes memory data =
@@ -406,7 +406,6 @@ contract InitRoleAndHoldersAndPermissions is LlamaGovernanceScriptTest {
     (ActionInfo memory actionInfo) = _createAction(data);
     _expectInitializeRolesEvents(descriptions);
     _expectRoleHolderEvents(roleHolders);
-    _expectRolePermissionEvents(permissionData);
     mpCore.executeAction(actionInfo);
   }
 


### PR DESCRIPTION
**Motivation:**

This PR updates several functions on the governance script to target more opinionated workflows rather than batch governance functions together in a generalized way.

**Modifications:**

- Remove all initRole functions besides allowing users to initialize a new role, grant this role to role holders (optional), and grant permissions to this role (optional).
- Limit create strategies functions to a single function that allows users to create a single new strategy and grant role permissions only using that strategy
- Remove `revokePolicy` functions in favor of a single `updateRoleDescriptionAndRoleHolders`. This allows users to update one role description and grant and remove role holders of that created role.
- Update the `createAccountAndSetRolePermissions` function so the computed account address is used for granting permissions and require permissions to only be granted not removed.

**Result:**

This governance script will help users fall in the pit of success with more opinionated ways to self-govern their instance without overloading actions.
