### PR TITLE
refactor: improve struct naming, natspec, and logic of governance script

### DIFF
--- a/test/llama-scripts/LlamaGovernanceScript.t.sol
+++ b/test/llama-scripts/LlamaGovernanceScript.t.sol
@@ -566,7 +566,7 @@ contract UpdateRoleDescriptionAndRoleHolders is LlamaGovernanceScriptTest {
 contract CreateAccountAndSetRolePermissions is LlamaGovernanceScriptTest {
   function test_CreateAccountAndSetRolePermissions() public {
     bytes memory config = abi.encode(LlamaAccount.Config({name: "mockAccountERC20"}));
-    LlamaGovernanceScript.CreateAccounts memory account = LlamaGovernanceScript.CreateAccounts(accountLogic, config);
+    LlamaGovernanceScript.CreateAccount memory account = LlamaGovernanceScript.CreateAccount(accountLogic, config);
 
     ILlamaAccount accountAddress = lens.computeLlamaAccountAddress(address(accountLogic), config, address(mpCore));
 


### PR DESCRIPTION
**Motivation:**

Reviewed the governance script again before deploying and found some ways to improve it.

**Modifications:**

- Fix outdated natspec
- Remove an unnecessary address cast in `setScriptAuthAndSetPermissions`
- Rename `CreateAccounts` struct to `CreateAccount`
- Simplify how the `PermissionData` struct is handled in `initRoleAndHoldersAndPermissions`

**Result:**

We will be ready to deploy the governance script.
