### PR TITLE
test: add assume statement for preventing fuzz tests from using restricted addresses

### DIFF
--- a/test/llama-scripts/LlamaGovernanceScript.t.sol
+++ b/test/llama-scripts/LlamaGovernanceScript.t.sol
@@ -648,6 +648,8 @@ contract CreateAccountAndSetRolePermissions is LlamaGovernanceScriptTest {
 
 contract SetScriptAuthAndSetPermissions is LlamaGovernanceScriptTest {
   function test_SetScriptAuthAndSetPermissions(address script, bool authorized) public {
+    vm.assume(script != address(mpCore));
+    vm.assume(script != address(mpPolicy));
     LlamaGovernanceScript.NewRolePermissionsData[] memory newRolePermissionsData =
       new LlamaGovernanceScript.NewRolePermissionsData[](2);
 


### PR DESCRIPTION
**Motivation:**

A fuzz test was failing because a restricted address was being used as a parameter for authorizing a script.

**Modifications:**

Added assume statements so the core and policy contracts won't be used as the script address parameter to `setScriptAuthorization`.

**Result:**

CI will pass.
